### PR TITLE
fix: fixing types when using GetRepository* methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - '10'
 
 script:
+  - yarn build
   - yarn lint
   - yarn test
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gh-pages-deploy": "^0.5.1",
     "mocha": "^5.2.0",
     "mock-cloud-firestore": "^0.9.0",
-    "reflect-metadata": "^0.1.12",
+    "reflect-metadata": "^0.1.13",
     "sinon": "^7.2.4",
     "ts-node": "^7.0.1",
     "tslint": "^5.12.0",
@@ -56,5 +56,8 @@
     ],
     "commit": "Releasing version",
     "noprompt": true
+  },
+  "peerDependencies": {
+    "reflect-metadata": "^0.1.13"
   }
 }

--- a/src/BaseFirestoreRepository.ts
+++ b/src/BaseFirestoreRepository.ts
@@ -12,7 +12,6 @@ import {
 } from './types';
 
 import {
-  Firestore,
   DocumentSnapshot,
   CollectionReference,
   WhereFilterOp,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,24 +2,24 @@ import { getMetadataStorage } from './MetadataStorage';
 import BaseFirestoreRepository from './BaseFirestoreRepository';
 import { IEntity } from './types';
 
-export function GetRepository(
-  entity: { new (): IEntity },
+export function GetRepository<T extends IEntity>(
+  entity: { new (): T },
   docId?: string,
   subColName?: string
 ) {
   return _getRepository(entity, 'default', docId, subColName);
 }
 
-export function GetCustomRepository(
-  entity: { new (): IEntity },
+export function GetCustomRepository<T extends IEntity>(
+  entity: { new (): T },
   docId?: string,
   subColName?: string
 ) {
   return _getRepository(entity, 'custom', docId, subColName);
 }
 
-export function GetBaseRepository(
-  entity: { new (): IEntity },
+export function GetBaseRepository<T extends IEntity>(
+  entity: { new (): T },
   docId?: string,
   subColName?: string
 ) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "outDir": "lib"
   },
   "compileOnSave": true,
-  "include": ["src"]
+  "include": ["src", "examples"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1845,9 +1845,10 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-reflect-metadata@^0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.12.tgz#311bf0c6b63cd782f228a81abe146a2bfa9c56f2"
+reflect-metadata@^0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
 
 request@^2.79.0, request@^2.81.0, request@^2.85.0:
   version "2.88.0"


### PR DESCRIPTION
This was a regression bug after implementing `IEntity`.

- [x] Add a step that checks for Typescript compiler errors.