### PR TITLE
Fixed IRepository's limit parameter, name changed to limitVal

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import QueryBuilder from './QueryBuilder';
 
 // TODO: separate Read/Write interfaces to achieve readonly?
 export interface IRepository<T extends { id: string }> {
-  limit(limit: number): QueryBuilder<T>;
+  limit(limitVal: number): QueryBuilder<T>;
   findById(id: string): Promise<T>;
   create(item: T): Promise<T>;
   update(item: T): Promise<T>;


### PR DESCRIPTION
I had originally defined the `limit` method as `limit(limit: number)`, when it should have been `limit(limitVal: number)`. 

I thought I had fixed this everywhere, but I forgot to fix this in the `types.ts` module. This PR addresses that.

This change should've been included in https://github.com/wovalle/fireorm/pull/19