### PR TITLE
Remove travis' compile stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,12 @@ node_js:
   - '10'
 
 stages:
-  - compile
   - test
   - name: deploy
     if: branch = master
 
 jobs:
   include:
-    - stage: compile
-      script: yarn build
-
     - stage: test
       script:
         - yarn lint


### PR DESCRIPTION
Based on [this](https://docs.travis-ci.com/user/build-stages/#specifying-stage-order-and-conditions), I initially was under the impression stages shared artifacts. This lead to [v0.5.0](https://github.com/wovalle/fireorm/releases/tag/v0.5.0) being broken and then fixed by @wovalle in #33