### PR TITLE
fix: transform GeoPoint to plain object

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ await todoRepository.update(mySuperTodoDocument); // Update todo
 await todoRepository.delete(mySuperTodoDocument.id); // Delete todo
 ```
 
+### Firebase Complex Data Types
+
+Firestore has support for [complex data types](https://firebase.google.com/docs/firestore/manage-data/data-types) such as GeoPoint and Reference. Full handling of complex data types is [being handled in this issue](https://github.com/wovalle/fireorm/issues/58). Temporarily, Fireorm will export [Class Transformer's @Type](https://github.com/typestack/class-transformer#working-with-nested-objects) decorator. It receives a lamda where you have to return the type you want to cast to. [See GeoPoint Example](https://github.com/wovalle/fireorm/blob/master/src/BaseFirestoreRepository.spec.ts#L338-L344).
+
+#### Limitations:
+
+If you want to cast GeoPoints to your custom class, it must have `latitude: number` and `longitude: number` as public class fields. Hopefully this won't be a limitation in v1.
+
 ## Development
 
 ### Initial Setup
@@ -115,20 +123,20 @@ This repo uses [Sematic Release](https://github.com/semantic-release/semantic-re
   <summary>Manual Release</summary>
   If, by any reason, a manual release must be done, these are the instructions:
 
--   To release a new version to npm, first we have to create a new tag:
+- To release a new version to npm, first we have to create a new tag:
 
 ```bash
 npm version [ major | minor | patch ] -m "Relasing version"
 git push --follow-tags
 ```
 
--   Then we can publish the package to npm registry:
+- Then we can publish the package to npm registry:
 
 ```bash
 npm publish
 ```
 
--   To deploy the documentation
+- To deploy the documentation
 
 ```bash
 yarn deploy:documentation # or npm deploy:documentation
@@ -138,7 +146,7 @@ yarn deploy:documentation # or npm deploy:documentation
 
 ### Documentation
 
--   Fireorm uses [typedoc](https://typedoc.org/) to automatically build the API documentation, to generate it:
+- Fireorm uses [typedoc](https://typedoc.org/) to automatically build the API documentation, to generate it:
 
 ```bash
 yarn build:documentation # or npm build:documentation
@@ -157,7 +165,6 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 
 <!-- prettier-ignore -->
-
 <table><tr><td align="center"><a href="http://twitter.com/wovalle"><img src="https://avatars0.githubusercontent.com/u/7854116?v=4" width="100px;" alt="Willy Ovalle"/><br /><sub><b>Willy Ovalle</b></sub></a><br /><a href="https://github.com/wovalle/fireorm/commits?author=wovalle" title="Code">💻</a> <a href="https://github.com/wovalle/fireorm/commits?author=wovalle" title="Documentation">📖</a> <a href="#example-wovalle" title="Examples">💡</a> <a href="#ideas-wovalle" title="Ideas, Planning, & Feedback">🤔</a> <a href="#review-wovalle" title="Reviewed Pull Requests">👀</a> <a href="https://github.com/wovalle/fireorm/commits?author=wovalle" title="Tests">⚠️</a></td><td align="center"><a href="https://github.com/mamodom"><img src="https://avatars3.githubusercontent.com/u/5097424?v=4" width="100px;" alt="Maximo Dominguez"/><br /><sub><b>Maximo Dominguez</b></sub></a><br /><a href="#ideas-mamodom" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/wovalle/fireorm/commits?author=mamodom" title="Code">💻</a></td><td align="center"><a href="https://github.com/jonesnc"><img src="https://avatars0.githubusercontent.com/u/1293145?v=4" width="100px;" alt="Nathan Jones"/><br /><sub><b>Nathan Jones</b></sub></a><br /><a href="https://github.com/wovalle/fireorm/commits?author=jonesnc" title="Code">💻</a></td></tr></table>
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/README.md
+++ b/README.md
@@ -123,20 +123,20 @@ This repo uses [Sematic Release](https://github.com/semantic-release/semantic-re
   <summary>Manual Release</summary>
   If, by any reason, a manual release must be done, these are the instructions:
 
-- To release a new version to npm, first we have to create a new tag:
+-   To release a new version to npm, first we have to create a new tag:
 
 ```bash
 npm version [ major | minor | patch ] -m "Relasing version"
 git push --follow-tags
 ```
 
-- Then we can publish the package to npm registry:
+-   Then we can publish the package to npm registry:
 
 ```bash
 npm publish
 ```
 
-- To deploy the documentation
+-   To deploy the documentation
 
 ```bash
 yarn deploy:documentation # or npm deploy:documentation
@@ -146,7 +146,7 @@ yarn deploy:documentation # or npm deploy:documentation
 
 ### Documentation
 
-- Fireorm uses [typedoc](https://typedoc.org/) to automatically build the API documentation, to generate it:
+-   Fireorm uses [typedoc](https://typedoc.org/) to automatically build the API documentation, to generate it:
 
 ```bash
 yarn build:documentation # or npm build:documentation
@@ -165,6 +165,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 
 <!-- prettier-ignore -->
+
 <table><tr><td align="center"><a href="http://twitter.com/wovalle"><img src="https://avatars0.githubusercontent.com/u/7854116?v=4" width="100px;" alt="Willy Ovalle"/><br /><sub><b>Willy Ovalle</b></sub></a><br /><a href="https://github.com/wovalle/fireorm/commits?author=wovalle" title="Code">💻</a> <a href="https://github.com/wovalle/fireorm/commits?author=wovalle" title="Documentation">📖</a> <a href="#example-wovalle" title="Examples">💡</a> <a href="#ideas-wovalle" title="Ideas, Planning, & Feedback">🤔</a> <a href="#review-wovalle" title="Reviewed Pull Requests">👀</a> <a href="https://github.com/wovalle/fireorm/commits?author=wovalle" title="Tests">⚠️</a></td><td align="center"><a href="https://github.com/mamodom"><img src="https://avatars3.githubusercontent.com/u/5097424?v=4" width="100px;" alt="Maximo Dominguez"/><br /><sub><b>Maximo Dominguez</b></sub></a><br /><a href="#ideas-mamodom" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/wovalle/fireorm/commits?author=mamodom" title="Code">💻</a></td><td align="center"><a href="https://github.com/jonesnc"><img src="https://avatars0.githubusercontent.com/u/1293145?v=4" width="100px;" alt="Nathan Jones"/><br /><sub><b>Nathan Jones</b></sub></a><br /><a href="https://github.com/wovalle/fireorm/commits?author=jonesnc" title="Code">💻</a></td></tr></table>
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ await todoRepository.delete(mySuperTodoDocument.id); // Delete todo
 
 Firestore has support for [complex data types](https://firebase.google.com/docs/firestore/manage-data/data-types) such as GeoPoint and Reference. Full handling of complex data types is [being handled in this issue](https://github.com/wovalle/fireorm/issues/58). Temporarily, Fireorm will export [Class Transformer's @Type](https://github.com/typestack/class-transformer#working-with-nested-objects) decorator. It receives a lamda where you have to return the type you want to cast to. [See GeoPoint Example](https://github.com/wovalle/fireorm/blob/master/src/BaseFirestoreRepository.spec.ts#L338-L344).
 
-#### Limitations:
+#### Limitations
 
 If you want to cast GeoPoints to your custom class, it must have `latitude: number` and `longitude: number` as public class fields. Hopefully this won't be a limitation in v1.
 

--- a/src/BaseFirestoreRepository.spec.ts
+++ b/src/BaseFirestoreRepository.spec.ts
@@ -2,7 +2,7 @@ import BaseFirestoreRepository from './BaseFirestoreRepository';
 import { getFixture, Album, Coordinates } from '../test/fixture';
 import { expect } from 'chai';
 import { Collection, SubCollection, ISubCollection, Initialize } from '.';
-import { Type } from 'class-transformer';
+import { Type } from './';
 const MockFirebase = require('mock-cloud-firestore');
 
 @Collection('bands')

--- a/src/BaseFirestoreRepository.spec.ts
+++ b/src/BaseFirestoreRepository.spec.ts
@@ -1,7 +1,8 @@
 import BaseFirestoreRepository from './BaseFirestoreRepository';
-import { getFixture, Album } from '../test/fixture';
+import { getFixture, Album, Coordinates } from '../test/fixture';
 import { expect } from 'chai';
 import { Collection, SubCollection, ISubCollection, Initialize } from '.';
+import { Type } from 'class-transformer';
 const MockFirebase = require('mock-cloud-firestore');
 
 @Collection('bands')
@@ -10,7 +11,12 @@ export class Band {
   name: string;
   formationYear: number;
   lastShow: Date;
+
+  // Todo create fireorm bypass decorator
+  @Type(() => Coordinates)
+  lastShowCoordinates: Coordinates;
   genres: Array<string>;
+
   @SubCollection(Album)
   albums?: ISubCollection<Album>;
 
@@ -328,6 +334,12 @@ describe('BaseRepository', () => {
       const pt = await bandRepository.findById('porcupine-tree');
       expect(pt.lastShow).to.be.instanceOf(Date);
       expect(pt.lastShow.toISOString()).to.equal('2010-10-14T00:00:00.000Z');
+    });
+    it('should correctly parse geopoints', async () => {
+      const pt = await bandRepository.findById('porcupine-tree');
+      expect(pt.lastShowCoordinates).to.be.instanceOf(Coordinates);
+      expect(pt.lastShowCoordinates.latitude).to.equal(51.5009088);
+      expect(pt.lastShowCoordinates.longitude).to.equal(-0.1795547);
     });
   });
 

--- a/src/BaseFirestoreRepository.ts
+++ b/src/BaseFirestoreRepository.ts
@@ -76,7 +76,7 @@ export default class BaseFirestoreRepository<T extends IEntity>
     // tslint:disable-next-line:no-unnecessary-type-assertion
     const entity = plainToClass(
       collection.entity as any,
-      this.parseTimestamp(doc.data() as T)
+      this.transformFirestoreTypes(doc.data() as T)
     ) as any;
 
     /*
@@ -106,13 +106,16 @@ export default class BaseFirestoreRepository<T extends IEntity>
     return q.docs.map(this.extractTFromDocSnap);
   };
 
-  private parseTimestamp = (obj: T): T => {
+  private transformFirestoreTypes = (obj: T): T => {
     Object.keys(obj).forEach(key => {
       if (!obj[key]) return;
       if (typeof obj[key] === 'object' && 'toDate' in obj[key]) {
         obj[key] = obj[key].toDate();
+      } else if (obj[key].constructor.name === 'GeoPoint') {
+        const { latitude, longitude } = obj[key];
+        obj[key] = { latitude, longitude };
       } else if (typeof obj[key] === 'object') {
-        this.parseTimestamp(obj[key]);
+        this.transformFirestoreTypes(obj[key]);
       }
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,6 @@ export * from './helpers';
 export { Initialize } from './MetadataStorage';
 
 export { Collection, SubCollection, CustomRepository, BaseFirestoreRepository };
+
+// Temporary while https://github.com/wovalle/fireorm/issues/58 is being fixed
+export { Type } from 'class-transformer';

--- a/test/fixture.ts
+++ b/test/fixture.ts
@@ -1,14 +1,22 @@
+import { GeoPoint } from "@google-cloud/firestore";
+
+export class Coordinates {
+  latitude: number;
+  longitude: number;
+}
 export class Album {
   id: string;
   name: string;
   releaseDate: Date;
   comment?: string;
 }
+
 export class BandEntity {
   id: string;
   name: string;
   formationYear: number;
   lastShow: Date;
+  lastShowCoordinates?: GeoPoint;
   genres: Array<string>;
   albums: Array<Album>;
 }
@@ -29,6 +37,7 @@ const getColFixture = () => {
     name: 'Porcupine Tree',
     formationYear: 1987,
     lastShow: new Date('2010-10-14'),
+    lastShowCoordinates: new GeoPoint(51.5009088, -0.1795547),
     genres: ['psychedelic-rock', 'progressive-rock', 'progressive-metal'],
     albums: [
       {


### PR DESCRIPTION
closes #48
I think this is kind of a hack, but it's what's being done with
firestore timestamps. You can find more information about this issue
[here](https://github.com/typestack/class-transformer/issues/174)