### PR TITLE
Fix: limit expression call more than once

### DIFF
--- a/src/BaseFirestoreRepository.spec.ts
+++ b/src/BaseFirestoreRepository.spec.ts
@@ -4,10 +4,11 @@ import { expect } from 'chai';
 import { Collection, SubCollection, ISubCollection, Initialize } from '.';
 import { Type } from './';
 import { MetadataStorage } from './MetadataStorage';
+
 const MockFirebase = require('mock-cloud-firestore');
 
 describe('BaseRepository', () => {
-  const store = { metadataStorage: new MetadataStorage() };
+  const store = {metadataStorage: new MetadataStorage()};
   Initialize(null, store);
 
   @Collection('bands')
@@ -34,7 +35,8 @@ describe('BaseRepository', () => {
     }
   }
 
-  class BandRepository extends BaseFirestoreRepository<Band> {}
+  class BandRepository extends BaseFirestoreRepository<Band> {
+  }
 
   let bandRepository: BaseFirestoreRepository<Band> | null = null;
 
@@ -79,7 +81,7 @@ describe('BaseRepository', () => {
     });
 
     it('must throw an exception if limit call more than once', async () => {
-      expect(()=> bandRepository.limit(2).limit(2).find()).to.throw();
+      expect(() => bandRepository.limit(2).limit(2).find()).to.throw();
     });
   });
 
@@ -285,7 +287,7 @@ describe('BaseRepository', () => {
       });
     });
 
-    it("must return same list if where filter doesn't apply", async () => {
+    it('must return same list if where filter doesn\'t apply', async () => {
       const list = await bandRepository
         .whereGreaterOrEqualThan('formationYear', 1983)
         .find();
@@ -428,7 +430,7 @@ describe('BaseRepository', () => {
     describe('miscellaneous', () => {
       it('should correctly parse dates', async () => {
         const pt = await bandRepository.findById('porcupine-tree');
-        const { releaseDate } = await pt.albums.findById('deadwing');
+        const {releaseDate} = await pt.albums.findById('deadwing');
         expect(releaseDate).instanceOf(Date);
         expect(releaseDate.toISOString()).to.equal('2005-03-25T00:00:00.000Z');
       });

--- a/src/BaseFirestoreRepository.spec.ts
+++ b/src/BaseFirestoreRepository.spec.ts
@@ -4,11 +4,10 @@ import { expect } from 'chai';
 import { Collection, SubCollection, ISubCollection, Initialize } from '.';
 import { Type } from './';
 import { MetadataStorage } from './MetadataStorage';
-
 const MockFirebase = require('mock-cloud-firestore');
 
 describe('BaseRepository', () => {
-  const store = {metadataStorage: new MetadataStorage()};
+  const store = { metadataStorage: new MetadataStorage() };
   Initialize(null, store);
 
   @Collection('bands')
@@ -35,8 +34,7 @@ describe('BaseRepository', () => {
     }
   }
 
-  class BandRepository extends BaseFirestoreRepository<Band> {
-  }
+  class BandRepository extends BaseFirestoreRepository<Band> {}
 
   let bandRepository: BaseFirestoreRepository<Band> | null = null;
 
@@ -81,7 +79,7 @@ describe('BaseRepository', () => {
     });
 
     it('must throw an exception if limit call more than once', async () => {
-      expect(() => bandRepository.limit(2).limit(2).find()).to.throw();
+      expect(()=> bandRepository.limit(2).limit(2).find()).to.throw();
     });
   });
 
@@ -287,7 +285,7 @@ describe('BaseRepository', () => {
       });
     });
 
-    it('must return same list if where filter doesn\'t apply', async () => {
+    it("must return same list if where filter doesn't apply", async () => {
       const list = await bandRepository
         .whereGreaterOrEqualThan('formationYear', 1983)
         .find();
@@ -430,7 +428,7 @@ describe('BaseRepository', () => {
     describe('miscellaneous', () => {
       it('should correctly parse dates', async () => {
         const pt = await bandRepository.findById('porcupine-tree');
-        const {releaseDate} = await pt.albums.findById('deadwing');
+        const { releaseDate } = await pt.albums.findById('deadwing');
         expect(releaseDate).instanceOf(Date);
         expect(releaseDate.toISOString()).to.equal('2005-03-25T00:00:00.000Z');
       });

--- a/src/BaseFirestoreRepository.spec.ts
+++ b/src/BaseFirestoreRepository.spec.ts
@@ -77,6 +77,10 @@ describe('BaseRepository', () => {
       const albumsLimited = await albumsSubColl.limit(2).find();
       expect(albumsLimited.length).to.equal(2);
     });
+
+    it('must throw an exception if limit call more than once', async () => {
+      expect(()=> bandRepository.limit(2).limit(2).find()).to.throw();
+    });
   });
 
   describe('orderByAscending', () => {

--- a/src/BaseFirestoreRepository.spec.ts
+++ b/src/BaseFirestoreRepository.spec.ts
@@ -79,7 +79,7 @@ describe('BaseRepository', () => {
     });
 
     it('must throw an exception if limit call more than once', async () => {
-      expect(()=> bandRepository.limit(2).limit(2).find()).to.throw();
+      expect(() => bandRepository.limit(2).limit(2).find()).to.throw();
     });
   });
 

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -73,6 +73,10 @@ export default class QueryBuilder<T extends IEntity>
   }
 
   limit(limitVal: number): QueryBuilder<T> {
+    if (this.limitVal) {
+      throw new Error('A limit function cannot be called more than once in the same query expression');
+    }
+
     this.limitVal = limitVal;
     return this;
   }

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -76,7 +76,6 @@ export default class QueryBuilder<T extends IEntity>
     if (this.limitVal) {
       throw new Error('A limit function cannot be called more than once in the same query expression');
     }
-
     this.limitVal = limitVal;
     return this;
   }


### PR DESCRIPTION
- [x] Throw an error on call `.limit()` more than once
- [x] Add unit tests

Closes issue #45 