### PR TITLE
Feature: adding filter by subfield

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,8 @@
         "--colors",
         "--require",
         "ts-node/register",
+        "--require",
+        "dotenv/config",
         "${relativeFile}"
       ],
       "cwd": "${workspaceRoot}",
@@ -40,6 +42,8 @@
       "args": [
         "--require",
         "ts-node/register",
+        "--require",
+        "dotenv/config",
         "--ui",
         "bdd",
         "--timeout",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:md": "remark README.md -o README.md",
     "release": "semantic-release",
     "test": "mocha --require ts-node/register --extension ts --recursive src",
-    "test:integration": "mocha --require ts-node/register --extension ts --recursive -t 10000 --file test/setup.ts test",
+    "test:integration": "mocha --require ts-node/register -r dotenv/config --extension ts --recursive -t 10000 --file test/setup.ts test",
     "test:watch": "mocha --require ts-node/register --extension ts --recursive -w src"
   },
   "dependencies": {
@@ -45,6 +45,7 @@
     "@types/pluralize": "^0.0.29",
     "@types/uuid": "^3.4.5",
     "chai": "^4.2.0",
+    "dotenv": "^8.1.0",
     "firebase-admin": "^8.1.0",
     "husky": "^2.3.0",
     "mocha": "^6.1.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "class-transformer": "^0.2.0",
-    "pluralize": "^8.0.0"
+    "pluralize": "^8.0.0",
+    "ts-object-path": "^0.1.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.6.1",

--- a/src/BaseFirestoreRepository.spec.ts
+++ b/src/BaseFirestoreRepository.spec.ts
@@ -280,6 +280,14 @@ describe('BaseRepository', () => {
   });
 
   describe('.where*', () => {
+    it('whereEqualTo must accept function as first parameter', async () => {
+      const list = await bandRepository
+        .whereEqualTo(b => b.name, 'Porcupine Tree')
+        .find();
+      expect(list.length).to.equal(1);
+      expect(list[0].name).to.equal('Porcupine Tree');
+    });
+
     it('must return T[]', async () => {
       const progressiveRockBands = await bandRepository
         .whereArrayContains('genres', 'progressive-rock')

--- a/src/BaseFirestoreRepository.ts
+++ b/src/BaseFirestoreRepository.ts
@@ -21,6 +21,7 @@ import {
   IOrderByParams,
   IQueryExecutor,
   IEntity,
+  IWherePropParam,
 } from './types';
 
 import {
@@ -224,7 +225,7 @@ export default class BaseFirestoreRepository<T extends IEntity>
     return query.get().then(this.extractTFromColSnap);
   }
 
-  whereEqualTo(prop: keyof T, val: IFirestoreVal): QueryBuilder<T> {
+  whereEqualTo(prop: IWherePropParam<T>, val: IFirestoreVal): QueryBuilder<T> {
     return new QueryBuilder<T>(this).whereEqualTo(prop, val);
   }
 

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -1,3 +1,5 @@
+import { getPath } from 'ts-object-path';
+
 import {
   IQueryBuilder,
   IFireOrmQueryLine,
@@ -6,6 +8,7 @@ import {
   FirestoreOperators,
   IQueryExecutor,
   IEntity,
+  IWherePropParam,
 } from './types';
 
 export default class QueryBuilder<T extends IEntity>
@@ -18,54 +21,71 @@ export default class QueryBuilder<T extends IEntity>
   // fields if the indexes are not created
   constructor(protected executor: IQueryExecutor<T>) {}
 
-  whereEqualTo(prop: keyof T, val: IFirestoreVal): QueryBuilder<T> {
+  private extractWhereParam = (param: IWherePropParam<T>) => {
+    if (typeof param === 'string') return param;
+    return getPath(param as Function).join('.');
+  };
+
+  whereEqualTo(param: IWherePropParam<T>, val: IFirestoreVal): QueryBuilder<T> {
     this.queries.push({
-      prop: prop.toString(),
+      prop: this.extractWhereParam(param),
       val,
       operator: FirestoreOperators.equal,
     });
     return this;
   }
 
-  whereGreaterThan(prop: keyof T, val: IFirestoreVal): QueryBuilder<T> {
+  whereGreaterThan(
+    prop: IWherePropParam<T>,
+    val: IFirestoreVal
+  ): QueryBuilder<T> {
     this.queries.push({
-      prop: prop.toString(),
+      prop: this.extractWhereParam(prop),
       val,
       operator: FirestoreOperators.greaterThan,
     });
     return this;
   }
 
-  whereGreaterOrEqualThan(prop: keyof T, val: IFirestoreVal): QueryBuilder<T> {
+  whereGreaterOrEqualThan(
+    prop: IWherePropParam<T>,
+    val: IFirestoreVal
+  ): QueryBuilder<T> {
     this.queries.push({
-      prop: prop.toString(),
+      prop: this.extractWhereParam(prop),
       val,
       operator: FirestoreOperators.greaterThanEqual,
     });
     return this;
   }
 
-  whereLessThan(prop: keyof T, val: IFirestoreVal): QueryBuilder<T> {
+  whereLessThan(prop: IWherePropParam<T>, val: IFirestoreVal): QueryBuilder<T> {
     this.queries.push({
-      prop: prop.toString(),
+      prop: this.extractWhereParam(prop),
       val,
       operator: FirestoreOperators.lessThan,
     });
     return this;
   }
 
-  whereLessOrEqualThan(prop: keyof T, val: IFirestoreVal): QueryBuilder<T> {
+  whereLessOrEqualThan(
+    prop: IWherePropParam<T>,
+    val: IFirestoreVal
+  ): QueryBuilder<T> {
     this.queries.push({
-      prop: prop.toString(),
+      prop: this.extractWhereParam(prop),
       val,
       operator: FirestoreOperators.lessThanEqual,
     });
     return this;
   }
 
-  whereArrayContains(prop: keyof T, val: IFirestoreVal): QueryBuilder<T> {
+  whereArrayContains(
+    prop: IWherePropParam<T>,
+    val: IFirestoreVal
+  ): QueryBuilder<T> {
     this.queries.push({
-      prop: prop.toString(),
+      prop: this.extractWhereParam(prop),
       val,
       operator: FirestoreOperators.arrayContains,
     });
@@ -74,15 +94,19 @@ export default class QueryBuilder<T extends IEntity>
 
   limit(limitVal: number): QueryBuilder<T> {
     if (this.limitVal) {
-      throw new Error('A limit function cannot be called more than once in the same query expression');
+      throw new Error(
+        'A limit function cannot be called more than once in the same query expression'
+      );
     }
     this.limitVal = limitVal;
     return this;
   }
 
-  orderByAscending(prop: keyof T & string): QueryBuilder<T> {
+  orderByAscending(prop: IWherePropParam<T> & string): QueryBuilder<T> {
     if (this.orderByObj) {
-      throw new Error('An orderBy function cannot be called more than once in the same query expression')
+      throw new Error(
+        'An orderBy function cannot be called more than once in the same query expression'
+      );
     }
     this.orderByObj = {
       fieldPath: prop,
@@ -91,9 +115,11 @@ export default class QueryBuilder<T extends IEntity>
     return this;
   }
 
-  orderByDescending(prop: keyof T & string): QueryBuilder<T> {
+  orderByDescending(prop: IWherePropParam<T> & string): QueryBuilder<T> {
     if (this.orderByObj) {
-      throw new Error('An orderBy function cannot be called more than once in the same query expression')
+      throw new Error(
+        'An orderBy function cannot be called more than once in the same query expression'
+      );
     }
     this.orderByObj = {
       fieldPath: prop,

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,16 +39,28 @@ export interface IOrderByParams {
 }
 
 export type IQueryBuilderResult = IFireOrmQueryLine[];
-
+export type IWherePropParam<T> = keyof T | ((t: T) => unknown);
 export interface IQueryBuilder<T extends IEntity> {
-  whereEqualTo(prop: keyof T, val: IFirestoreVal): IQueryBuilder<T>;
-  whereGreaterThan(prop: keyof T, val: IFirestoreVal): IQueryBuilder<T>;
-  whereGreaterOrEqualThan(prop: keyof T, val: IFirestoreVal): IQueryBuilder<T>;
-  whereLessThan(prop: keyof T, val: IFirestoreVal): IQueryBuilder<T>;
-  whereLessOrEqualThan(prop: keyof T, val: IFirestoreVal): IQueryBuilder<T>;
-  whereArrayContains(prop: keyof T, val: IFirestoreVal): IQueryBuilder<T>;
-  orderByAscending(prop: keyof T & string): IQueryBuilder<T>;
-  orderByDescending(prop: keyof T & string): IQueryBuilder<T>;
+  whereEqualTo(prop: IWherePropParam<T>, val: IFirestoreVal): IQueryBuilder<T>;
+  whereGreaterThan(
+    prop: IWherePropParam<T>,
+    val: IFirestoreVal
+  ): IQueryBuilder<T>;
+  whereGreaterOrEqualThan(
+    prop: IWherePropParam<T>,
+    val: IFirestoreVal
+  ): IQueryBuilder<T>;
+  whereLessThan(prop: IWherePropParam<T>, val: IFirestoreVal): IQueryBuilder<T>;
+  whereLessOrEqualThan(
+    prop: IWherePropParam<T>,
+    val: IFirestoreVal
+  ): IQueryBuilder<T>;
+  whereArrayContains(
+    prop: IWherePropParam<T>,
+    val: IFirestoreVal
+  ): IQueryBuilder<T>;
+  orderByAscending(prop: IWherePropParam<T> & string): IQueryBuilder<T>;
+  orderByDescending(prop: IWherePropParam<T> & string): IQueryBuilder<T>;
   find(): Promise<T[]>;
 }
 

--- a/test/functional/1-simple_repository.spec.ts
+++ b/test/functional/1-simple_repository.spec.ts
@@ -4,8 +4,10 @@ import { expect } from 'chai';
 import { getUniqueColName } from '../setup';
 
 describe('Integration test: Simple Repository', () => {
-  @Collection(getUniqueColName('band'))
-  class Band extends BandEntity {}
+  @Collection(getUniqueColName('band-simple-repository'))
+  class Band extends BandEntity {
+    extra?: { website: string };
+  }
 
   const bandRepository = GetRepository(Band);
 
@@ -16,6 +18,9 @@ describe('Integration test: Simple Repository', () => {
     dt.name = 'DreamTheater';
     dt.formationYear = 1985;
     dt.genres = ['progressive-metal', 'progressive-rock'];
+    dt.extra = {
+      website: 'www.dreamtheater.net',
+    };
 
     const savedBand = await bandRepository.create(dt);
     expect(savedBand.name).to.equal(dt.name);
@@ -44,6 +49,13 @@ describe('Integration test: Simple Repository', () => {
     const updatedDtInDb = await bandRepository.findById(dt.id);
     expect(updatedDt.name).to.equal(dt.name);
     expect(updatedDtInDb.name).to.equal(dt.name);
+
+    // Filter a band by subfield
+    const byWebsite = await bandRepository
+      .whereEqualTo(a => a.extra.website, 'www.dreamtheater.net')
+      .find();
+
+    expect(byWebsite[0].id).to.equal('dream-theater');
 
     // Delete a band
     await bandRepository.delete(dt.id);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -40,5 +40,6 @@ after(async () => {
 export const getUniqueColName = (col: string) => {
   const unique = `${col}#${uuid.v4()}`;
   uniqueCollections.push(unique);
+  console.log(`Now using collection: ${unique}`);
   return unique;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1791,7 +1791,7 @@ debug@^4.0.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -1962,6 +1962,11 @@ dotenv@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
   integrity sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==
+
+dotenv@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.1.0.tgz#d811e178652bfb8a1e593c6dd704ec7e90d85ea2"
+  integrity sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA==
 
 duplexer2@~0.1.0:
   version "0.1.4"
@@ -3122,7 +3127,7 @@ import-lazy@^2.1.0:
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
   integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -3766,7 +3771,7 @@ libnpm@^3.0.0:
     read-package-json "^2.0.13"
     stringify-package "^1.0.0"
 
-libnpmaccess@*, libnpmaccess@^3.0.1:
+libnpmaccess@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-3.0.1.tgz#5b3a9de621f293d425191aa2e779102f84167fa8"
   integrity sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==
@@ -3795,7 +3800,7 @@ libnpmhook@^5.0.2:
     get-stream "^4.0.0"
     npm-registry-fetch "^3.8.0"
 
-libnpmorg@*, libnpmorg@^1.0.0:
+libnpmorg@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/libnpmorg/-/libnpmorg-1.0.0.tgz#979b868c48ba28c5820e3bb9d9e73c883c16a232"
   integrity sha512-o+4eVJBoDGMgRwh2lJY0a8pRV2c/tQM/SxlqXezjcAg26Qe9jigYVs+Xk0vvlYDWCDhP0g74J8UwWeAgsB7gGw==
@@ -3829,7 +3834,7 @@ libnpmsearch@^2.0.0, libnpmsearch@^2.0.1:
     get-stream "^4.0.0"
     npm-registry-fetch "^3.8.0"
 
-libnpmteam@*, libnpmteam@^1.0.1:
+libnpmteam@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/libnpmteam/-/libnpmteam-1.0.1.tgz#ff704b1b6c06ea674b3b1101ac3e305f5114f213"
   integrity sha512-gDdrflKFCX7TNwOMX1snWojCoDE5LoRWcfOC0C/fqF7mBq8Uz9zWAX4B2RllYETNO7pBupBaSyBDkTAC15cAMg==
@@ -3914,11 +3919,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -3927,32 +3927,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -4033,11 +4011,6 @@ lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -4753,7 +4726,7 @@ npm-prefix@^1.2.0:
     shellsubstitute "^1.1.0"
     untildify "^2.1.0"
 
-npm-profile@*, npm-profile@^4.0.1:
+npm-profile@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-profile/-/npm-profile-4.0.1.tgz#d350f7a5e6b60691c7168fbb8392c3603583f5aa"
   integrity sha512-NQ1I/1Q7YRtHZXkcuU1/IyHeLy6pd+ScKg4+DQHdfsm769TGq6HPrkbuNJVJS4zwE+0mvvmeULzQdWn2L2EsVA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6715,6 +6715,11 @@ ts-node@^8.3.0:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
+ts-object-path@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ts-object-path/-/ts-object-path-0.1.2.tgz#7bbfa50a9a3970bcdd7e67470d00fb54ca22a6c7"
+  integrity sha512-YLX9omkbe2spFv7DDo1fC5BiRfMtu/LgYuGSXnuIT5EkhedzCEShT7YrsQV3pjjT7doY2RHfoxJrra16KJlf7w==
+
 tslib@1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"


### PR DESCRIPTION
Closes #73 

Now all the `.where*` filter accept a a lamda (where T is the first parameter) to support type-safe querying by subfield (or field, but that was previously covered with typeof T).