### PR TITLE
WIP Query builder additional query methods

### DIFF
--- a/src/AbstractFirestoreRepository.ts
+++ b/src/AbstractFirestoreRepository.ts
@@ -268,6 +268,17 @@ export abstract class AbstractFirestoreRepository<T extends IEntity>
     return new QueryBuilder<T>(this).orderByDescending(prop);
   }
 
+  startAt(prop: number): IQueryBuilder<T> {
+    return new QueryBuilder<T>(this).startAt(prop);
+  }
+  startAfter(prop: number): IQueryBuilder<T> {
+    return new QueryBuilder<T>(this).startAfter(prop);
+  }
+
+  endAt(prop: number): IQueryBuilder<T> {
+    return new QueryBuilder<T>(this).endAt(prop);
+  }
+
   /**
    * Execute the query and applies all the filters (if specified)
    *
@@ -279,6 +290,14 @@ export abstract class AbstractFirestoreRepository<T extends IEntity>
     return new QueryBuilder<T>(this).find();
   }
 
+  count(): Promise<number> {
+    return new QueryBuilder<T>(this).count();
+  }
+
+  findOne(): Promise<T> {
+    return new QueryBuilder<T>(this).findOne();
+  }
+
   /**
    * Takes all the queries stored by QueryBuilder and executes them.
    * Must be implemented by base repositores
@@ -288,15 +307,31 @@ export abstract class AbstractFirestoreRepository<T extends IEntity>
    * QueryBuilder
    * @param {number} [limitVal] (Optional) if a limit constraint
    * should be applied
+   * @param {boolean} [countVal] queries list of queries stored in
+   * QueryBuilder
+   * @param {number} [offsetVal] queries list of queries stored in
+   * QueryBuilder
+   * @param {number} [startAtVal] queries list of queries stored in
+   * QueryBuilder
+   * @param {number} [startAfterVal] queries list of queries stored in
+   * QueryBuilder
+   * @param {number} [endAtVal] queries list of queries stored in
+   * QueryBuilder
    * @param {IOrderByParams} [orderByObj] (Optional) if a sortBy
    * clause should be applied
    * @returns {Promise<T[]>} results from firestore converted into
    * entities <T>
    * @memberof AbstractFirestoreRepository
    */
+
   abstract execute(
     queries: IFireOrmQueryLine[],
     limitVal?: number,
-    orderByObj?: IOrderByParams
-  ): Promise<T[]>;
+    countVal?: boolean,
+    offsetVal?: number,
+    startAtVal?: any,
+    startAfterVal?: any,
+    endAtVal?: any,
+    orderByObj?: IOrderByParams): Promise<T[]>;
+
 }

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -167,7 +167,7 @@ export default class QueryBuilder<T extends IEntity>
     return this;
   }
   count(): Promise<number>{
-    return this.executor.execute(this.queries, this.limitVal, true, this.offsetVal, this.startAtVal, this.startAfterVal, this.endAtVal, this.orderByObj).then(count => count.pop()) as Promise<any>;
+    return this.executor.execute(this.queries, this.limitVal, true, this.offsetVal, this.startAtVal, this.startAfterVal, this.endAtVal, this.orderByObj).then(count => count.pop()) as Promise<number>;
   }
 
   find(): Promise<T[]> {

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -15,6 +15,11 @@ export default class QueryBuilder<T extends IEntity>
   implements IQueryBuilder<T> {
   protected queries: Array<IFireOrmQueryLine> = [];
   protected limitVal: number;
+  protected countVal: boolean;
+  protected offsetVal: number;
+  protected startAtVal: any;
+  protected startAfterVal: any;
+  protected endAtVal: any;
   protected orderByObj: IOrderByParams;
 
   constructor(protected executor: IQueryExecutor<T>) {}
@@ -100,6 +105,38 @@ export default class QueryBuilder<T extends IEntity>
     return this;
   }
 
+  offset(offsetVal: number): QueryBuilder<T> {
+    if (this.offsetVal) {
+      throw new Error('A offset function cannot be called more than once in the same query expression');
+    }
+    this.offsetVal = offsetVal;
+    return this;
+  }
+
+  startAt(startAt: any): QueryBuilder<T>{
+    if (this.startAtVal) {
+      throw new Error('A startAt function cannot be called more than once in the same query expression');
+    }
+    this.startAtVal = startAt;
+    return this;
+  }
+
+  startAfter(startAfter: any): QueryBuilder<T>{
+    if (this.startAfterVal) {
+      throw new Error('A startAfter function cannot be called more than once in the same query expression');
+    }
+    this.startAfterVal = startAfter;
+    return this;
+  }
+
+  endAt(endAt: any): QueryBuilder<T>{
+    if (this.endAtVal) {
+      throw new Error('A endAt function cannot be called more than once in the same query expression');
+    }
+    this.endAtVal = endAt;
+    return this;
+  }
+
   orderByAscending(prop: IWherePropParam<T>): QueryBuilder<T> {
     if (this.orderByObj) {
       throw new Error(
@@ -129,8 +166,15 @@ export default class QueryBuilder<T extends IEntity>
 
     return this;
   }
+  count(): Promise<number>{
+    return this.executor.execute(this.queries, this.limitVal, true, this.offsetVal, this.startAtVal, this.startAfterVal, this.endAtVal, this.orderByObj).then(count => count.pop()) as Promise<any>;
+  }
 
   find(): Promise<T[]> {
-    return this.executor.execute(this.queries, this.limitVal, this.orderByObj);
+    return this.executor.execute(this.queries, this.limitVal,  this.countVal,  this.offsetVal, this.startAtVal, this.startAfterVal, this.endAtVal, this.orderByObj);
+  }
+
+  findOne(): Promise<T> {
+    return this.executor.execute(this.queries, this.limitVal, this.countVal, this.offsetVal, this.startAtVal, this.startAfterVal, this.endAtVal, this.orderByObj).then(res => res.pop());
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,16 +66,26 @@ export interface IQueryBuilder<T extends IEntity> {
     prop: IWherePropParam<T>,
     val: IFirestoreVal
   ): IQueryBuilder<T>;
+  limit(limitVal: number): IQueryBuilder<T>;
   orderByAscending(prop: IWherePropParam<T>): IQueryBuilder<T>;
   orderByDescending(prop: IWherePropParam<T>): IQueryBuilder<T>;
-  limit(limitVal: number): IQueryBuilder<T>;
+  startAt(prop: any): IQueryBuilder<T>;
+  startAfter(prop: any): IQueryBuilder<T>;
+  endAt(prop: any): IQueryBuilder<T>;
   find(): Promise<T[]>;
+  findOne(): Promise<T>;
+  count(): Promise<number>;
 }
 
 export interface IQueryExecutor<T> {
   execute(
     queries: IFireOrmQueryLine[],
     limitVal?: number,
+    countVal?: boolean,
+    offsetVal?: number,
+    startAtVal?: any,
+    startAfterVal?: any,
+    endAtVal?: any,
     orderByObj?: IOrderByParams
   ): Promise<T[]>;
 }


### PR DESCRIPTION
**Description**    
   For my personal development implementations I've been looking for a way to use additional QueryBuilder methods in couple with other query-filters such as **where/limit** conditions. The most simple way I've found is extending QueryBuilder properties and then just put them into **QueryBuilder.find()** as an input parameters. For now I can see that the count of **8** input parameters in total are looks a little bit ugly. 
@wovalle: My proposal is simply have to take a look at current solution and give me your feedback about is that suitable? 
    Then I will add test cases either I need some feedback how can I make to refactor or some another ideas how we can use this methods with query builder. That is the simple case which prevents me currently to implement FireORM as a dependency.
Thank you in advance
**Reason**
Have a possibility to use **startAt**, **offset**, **startAfter**, **endAt**, **count**,**findOne** in one query with the where/limit conditions