### PR TITLE
chore: export old initialize

### DIFF
--- a/src/MetadataStorage.ts
+++ b/src/MetadataStorage.ts
@@ -120,3 +120,8 @@ export const initialize = (firestore: Firestore): void => {
   initializeMetadataStorage();
   getStore().metadataStorage.firestoreRef = firestore;
 };
+
+/**
+ * @deprecated Use initialize. This will be removed in a future version.
+ */
+export const Initialize = initialize;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,7 +11,7 @@ export function getRepository<T extends IEntity>(
 }
 
 /**
- * @deprecated Use getRepository
+ * @deprecated Use getRepository. This will be removed in a future version.
  */
 export const GetRepository = getRepository;
 
@@ -24,7 +24,7 @@ export function getCustomRepository<T extends IEntity>(
 }
 
 /**
- * @deprecated Use getCustomRepository
+ * @deprecated Use getCustomRepository. This will be removed in a future version.
  */
 export const GetCustomRepository = getCustomRepository;
 
@@ -37,7 +37,7 @@ export function getBaseRepository<T extends IEntity>(
 }
 
 /**
- * @deprecated Use getBaseRepository
+ * @deprecated Use getBaseRepository. This will be removed in a future version.
  */
 export const GetBaseRepository = getBaseRepository;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export * from './Decorators';
 export * from './BaseFirestoreRepository';
 export * from './types';
 export * from './helpers';
-export { initialize } from './MetadataStorage';
+export { initialize, Initialize } from './MetadataStorage';
 
 // Temporary while https://github.com/wovalle/fireorm/issues/58 is being fixed
 export { Type } from 'class-transformer';


### PR DESCRIPTION
Noticed that when the PR to camelCase the helper functions was merged, I forgot to export the old `Initialize` function. Quick PR to fix so that it isn't a breaking change 