### PR TITLE
fix: fix validation

### DIFF
--- a/docgen/Validation.md
+++ b/docgen/Validation.md
@@ -2,6 +2,10 @@
 
 FireORM supports [class-validator](https://github.com/typestack/class-validator) validation decorators in any collection.
 
+As `class-validator` requires a single install per project, FireORM opts not to depend on it explicitly (doing so may result in conflicting versions). It is up to you to install it with `npm i -S class-validator`.
+
+Once installed correctly, you can write your collections like so:
+
 ```typescript
 import { Collection } from 'fireorm';
 import { IsEmail } from 'class-validator';

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/uuid": "^3.4.5",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
+    "class-validator": "^0.10.2",
     "docsify-cli": "^4.3.0",
     "dotenv": "^8.1.0",
     "firebase-admin": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "typescript": "^3.2.2"
   },
   "peerDependencies": {
-    "class-validator": "^0.8.0",
     "reflect-metadata": "^0.1.13"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "lint": "tslint --project tsconfig.json",
     "lint:md": "remark README.md -o README.md",
     "release": "semantic-release",
-    "test": "mocha --require ts-node/register test/setup.unit.ts --extension ts --recursive src",
+    "test": "mocha --require ts-node/register --extension ts --recursive src",
     "test:integration": "mocha --require ts-node/register -r dotenv/config --extension ts --recursive -t 10000 --file test/setup.ts test",
-    "test:watch": "mocha --require ts-node/register test/setup.unit.ts --extension ts --recursive -w src"
+    "test:watch": "mocha --require ts-node/register --extension ts --recursive -w src"
   },
   "dependencies": {
     "class-transformer": "^0.2.0",
@@ -50,7 +50,6 @@
     "@types/pluralize": "^0.0.29",
     "@types/uuid": "^3.4.5",
     "chai": "^4.2.0",
-    "chai-as-promised": "^7.1.1",
     "class-validator": "^0.10.2",
     "docsify-cli": "^4.3.0",
     "dotenv": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "class-transformer": "^0.2.0",
-    "class-validator": "^0.10.2",
     "pluralize": "^8.0.0",
     "ts-object-path": "^0.1.2"
   },
@@ -69,6 +68,7 @@
     "typescript": "^3.2.2"
   },
   "peerDependencies": {
+    "class-validator": "^0.8.0",
     "reflect-metadata": "^0.1.13"
   },
   "files": [

--- a/src/AbstractFirestoreRepository.ts
+++ b/src/AbstractFirestoreRepository.ts
@@ -20,7 +20,7 @@ import {
 
 import { BaseRepository } from './BaseRepository';
 import QueryBuilder from './QueryBuilder';
-import { ValidationError, validate } from 'class-validator';
+import { ValidationError } from 'class-validator';
 
 export abstract class AbstractFirestoreRepository<T extends IEntity>
   extends BaseRepository
@@ -307,19 +307,30 @@ export abstract class AbstractFirestoreRepository<T extends IEntity>
    * @returns {Promise<ValidationError[]>} An array of class-validator errors
    */
   async validate(item: T): Promise<ValidationError[]> {
-    const { getSubCollection, getCollection } = getMetadataStorage();
-    const { entity: Entity } = this.subColName
-      ? getSubCollection(this.subColName)
-      : getCollection(this.colName);
-
-    /**
-     * Instantiate plain objects into an entity class
-     */
-    const entity = item instanceof Entity
-        ? item
-        : Object.assign(new Entity(), item);
-
-    return validate(entity);
+    try {
+      const classValidator = await import('class-validator');
+      const { getSubCollection, getCollection } = getMetadataStorage();
+      const { entity: Entity } = this.subColName
+        ? getSubCollection(this.subColName)
+        : getCollection(this.colName);
+  
+      /**
+       * Instantiate plain objects into an entity class
+       */
+      const entity = item instanceof Entity
+          ? item
+          : Object.assign(new Entity(), item);
+  
+      return classValidator.validate(entity);
+    } catch (error) {
+      if (error.code === 'MODULE_NOT_FOUND') {
+        throw new Error(
+          'It looks like class-validator is not installed. Please run `npm i -S class-validator` to fix this error, or initialize FireORM with `validateModels: false` to disable validation.'
+        );
+      }
+      
+      throw error;
+    }
   }
 
   /**

--- a/src/AbstractFirestoreRepository.ts
+++ b/src/AbstractFirestoreRepository.ts
@@ -307,7 +307,10 @@ export abstract class AbstractFirestoreRepository<T extends IEntity>
    * @returns {Promise<ValidationError[]>} An array of class-validator errors
    */
   async validate(item: T): Promise<ValidationError[]> {
-    const { entity: Entity } = this.colMetadata;
+    const { getSubCollection, getCollection } = getMetadataStorage();
+    const { entity: Entity } = this.subColName
+      ? getSubCollection(this.subColName)
+      : getCollection(this.colName);
 
     /**
      * Instantiate plain objects into an entity class

--- a/src/BaseFirestoreRepository.spec.ts
+++ b/src/BaseFirestoreRepository.spec.ts
@@ -207,27 +207,10 @@ describe('BaseFirestoreRepository', () => {
       bandRepository = new BandRepository('bands');
 
       const entity = new Band();
-
       entity.contactEmail = 'Not an email';
+      const band = await bandRepository.create(entity);
 
-      await expect(bandRepository.create(entity)).not.to.be.rejected;
-    });
-
-    it('must pass validation if a valid class is given', async () => {
-      const entity = new Band();
-
-      entity.contactEmail = 'test@email.com';
-
-      await expect(bandRepository.create(entity)).not.to.be.rejected;
-    });
-
-    it('must pass validation if a valid object is given', async () => {
-      const entity: Partial<Band> = {
-        contactEmail: 'test@email.com',
-        id: '1234',
-      };
-
-      await expect(bandRepository.create(entity as Band)).not.to.be.rejected;
+      expect(band.contactEmail).to.equal('Not an email');
     });
 
     it('must fail validation if an invalid class is given', async () => {
@@ -235,10 +218,11 @@ describe('BaseFirestoreRepository', () => {
 
       entity.contactEmail = 'Not an email';
 
-      await expect(bandRepository.create(entity)).to.be.rejectedWith(
-        Error,
-        'failed the validation'
-      );
+      try {
+        await bandRepository.create(entity);
+      } catch (error) {
+        expect(error[0].constraints.isEmail).to.equal('Invalid email!')
+      }
     });
 
     it('must fail validation if an invalid object is given', async () => {
@@ -247,10 +231,11 @@ describe('BaseFirestoreRepository', () => {
         id: '1234',
       };
 
-      await expect(bandRepository.create(entity as Band)).to.be.rejectedWith(
-        Error,
-        'failed the validation'
-      );
+      try {
+        await bandRepository.create(entity as Band);
+      } catch (error) {
+        expect(error[0].constraints.isEmail).to.equal('Invalid email!')
+      }
     });
 
     it('must create items when id is passed', async () => {
@@ -308,29 +293,12 @@ describe('BaseFirestoreRepository', () => {
       bandRepository = new BandRepository('bands');
 
       const band = await bandRepository.findById('porcupine-tree');
-
       band.contactEmail = 'Not an email';
 
-      await expect(bandRepository.update(band)).not.to.be.rejected;
-    });
+      await bandRepository.update(band);
+      const updatedBand = await bandRepository.findById('porcupine-tree');
 
-    it('must pass validation if a valid class is given', async () => {
-      const band = await bandRepository.findById('porcupine-tree');
-
-      band.contactEmail = 'test@email.com';
-
-      await expect(bandRepository.update(band)).not.to.be.rejected;
-    });
-
-    it('must pass validation if a valid object is given', async () => {
-      const band = await bandRepository.findById('porcupine-tree');
-      const updatedBand: Partial<Band> = {
-        ...band,
-        contactEmail: 'test@email.com',
-      };
-
-      await expect(bandRepository.update(updatedBand as Band)).not.to.be
-        .rejected;
+      expect(updatedBand.contactEmail).to.equal('Not an email');
     });
 
     it('must fail validation if an invalid class is given', async () => {
@@ -338,10 +306,11 @@ describe('BaseFirestoreRepository', () => {
 
       band.contactEmail = 'Not an email';
 
-      await expect(bandRepository.update(band)).to.be.rejectedWith(
-        Error,
-        'failed the validation'
-      );
+      try {
+        await bandRepository.update(band);
+      } catch (error) {
+        expect(error[0].constraints.isEmail).to.equal('Invalid email!')
+      }
     });
 
     it('must fail validation if an invalid object is given', async () => {
@@ -351,9 +320,11 @@ describe('BaseFirestoreRepository', () => {
         contactEmail: 'Not an email',
       };
 
-      await expect(
-        bandRepository.update(updatedBand as Band)
-      ).to.be.rejectedWith(Error, 'failed the validation');
+      try {
+        await bandRepository.create(updatedBand as Band);
+      } catch (error) {
+        expect(error[0].constraints.isEmail).to.equal('Invalid email!')
+      }
     });
 
     it('must only update changed fields'); // TODO: Discuss
@@ -646,7 +617,11 @@ describe('BaseFirestoreRepository', () => {
       firstAlbum.name = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
       firstAlbum.releaseDate = new Date('2002-07-22');
 
-      await expect(band.albums.create(firstAlbum)).to.be.rejectedWith(Error, 'failed the validation');
+      try {
+        await band.albums.create(firstAlbum);
+      } catch (error) {
+        expect(error[0].constraints.length).to.equal('Name is too long');
+      }
     });
 
     it('should be able to update subcollections', async () => {
@@ -666,7 +641,11 @@ describe('BaseFirestoreRepository', () => {
 
       album.name = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
 
-      await expect(pt.albums.update(album)).to.be.rejectedWith(Error, 'failed the validation');
+      try {
+        await pt.albums.update(album);
+      } catch (error) {
+        expect(error[0].constraints.length).to.equal('Name is too long');
+      }
     });
 
     it('should be able to update collections with subcollections', async () => {

--- a/src/BaseFirestoreRepository.spec.ts
+++ b/src/BaseFirestoreRepository.spec.ts
@@ -632,6 +632,23 @@ describe('BaseFirestoreRepository', () => {
       expect(albums.length).to.eql(3);
     });
 
+    it('should be able to validate subcollections on create', async () => {
+      const band = new Band();
+      band.id = '30-seconds-to-mars';
+      band.name = '30 Seconds To Mars';
+      band.formationYear = 1998;
+      band.genres = ['alternative-rock'];
+
+      await bandRepository.create(band);
+
+      const firstAlbum = new Album();
+      firstAlbum.id = 'invalid-album-name';
+      firstAlbum.name = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+      firstAlbum.releaseDate = new Date('2002-07-22');
+
+      await expect(band.albums.create(firstAlbum)).to.be.rejectedWith(Error, 'failed the validation');
+    });
+
     it('should be able to update subcollections', async () => {
       const pt = await bandRepository.findById('porcupine-tree');
       const album = await pt.albums.findById('fear-blank-planet');
@@ -641,6 +658,15 @@ describe('BaseFirestoreRepository', () => {
 
       const updatedAlbum = await pt.albums.findById('fear-blank-planet');
       expect(updatedAlbum.comment).to.eql('Anesthethize is top 3 IMHO');
+    });
+
+    it('should be able to validate subcollections on update', async () => {
+      const pt = await bandRepository.findById('porcupine-tree');
+      const album = await pt.albums.findById('fear-blank-planet');
+
+      album.name = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+
+      await expect(pt.albums.update(album)).to.be.rejectedWith(Error, 'failed the validation');
     });
 
     it('should be able to update collections with subcollections', async () => {

--- a/src/BaseFirestoreRepository.ts
+++ b/src/BaseFirestoreRepository.ts
@@ -52,9 +52,9 @@ export class BaseFirestoreRepository<T extends IEntity>
   async create(item: T): Promise<T> {
     if (this.config.validateModels) {
       const errors = await this.validate(item);
-  
+
       if (errors.length) {
-        throw new Error(errors.toString());
+        throw errors;
       }
     }
 
@@ -87,7 +87,7 @@ export class BaseFirestoreRepository<T extends IEntity>
       const errors = await this.validate(item);
   
       if (errors.length) {
-        throw new Error(errors.toString());
+        throw errors;
       }
     }
 

--- a/src/BaseFirestoreRepository.ts
+++ b/src/BaseFirestoreRepository.ts
@@ -111,7 +111,7 @@ export class BaseFirestoreRepository<T extends IEntity>
         new TransactionRepository<T>(
           this.firestoreColRef,
           t,
-          this.colMetadata.entity
+          this.colName
         )
       );
     });

--- a/src/BaseFirestoreTransactionRepository.spec.ts
+++ b/src/BaseFirestoreTransactionRepository.spec.ts
@@ -101,30 +101,9 @@ describe('BaseFirestoreTransactionRepository', () => {
 
       await bandRepository.runTransaction(async tran => {
         const entity = new Band();
-  
         entity.contactEmail = 'Not an email';
-  
-        await expect(tran.create(entity)).not.to.be.rejected;
-      })
-    });
-
-    it('must pass validation if a valid class is given', async () => {
-      await bandRepository.runTransaction(async tran => {
-        const entity = new Band();
-  
-        entity.contactEmail = 'test@email.com';
-  
-        await expect(tran.create(entity)).not.to.be.rejected;
-      })
-    });
-
-    it('must pass validation if a valid object is given', async () => {
-      await bandRepository.runTransaction(async tran => {
-        const entity: Partial<Band> = {
-          contactEmail: 'test@email.com',
-        }
-  
-        await expect(tran.create(entity as Band)).not.to.be.rejected;
+        const band = await tran.create(entity);
+        expect(band.contactEmail).to.equal('Not an email');
       })
     });
 
@@ -133,8 +112,12 @@ describe('BaseFirestoreTransactionRepository', () => {
         const entity = new Band();
   
         entity.contactEmail = 'Not an email';
-  
-        await expect(tran.create(entity)).to.be.rejectedWith(Error, 'failed the validation');
+
+        try {
+          await tran.create(entity);
+        } catch (error) {
+          expect(error[0].constraints.isEmail).to.equal('Invalid email!');
+        }
       })
     });
 
@@ -143,8 +126,12 @@ describe('BaseFirestoreTransactionRepository', () => {
         const entity: Partial<Band> = {
           contactEmail: 'Not an email',
         }
-  
-        await expect(tran.create(entity as Band)).to.be.rejectedWith(Error, 'failed the validation');
+
+        try {
+          await tran.create(entity as Band);
+        } catch (error) {
+          expect(error[0].constraints.isEmail).to.equal('Invalid email!');
+        }
       })
     });
 
@@ -221,32 +208,10 @@ describe('BaseFirestoreTransactionRepository', () => {
 
       await bandRepository.runTransaction(async tran => {
         const band = await tran.findById('porcupine-tree');
-  
         band.contactEmail = 'Not an email';
-  
-        await expect(tran.update(band)).not.to.be.rejected;
-      })
-    });
-
-    it('must pass validation if a valid class is given', async () => {
-      await bandRepository.runTransaction(async tran => {
-        const band = await tran.findById('porcupine-tree');
-  
-        band.contactEmail = 'test@email.com';
-  
-        await expect(tran.update(band)).not.to.be.rejected;
-      })
-    });
-
-    it('must pass validation if a valid object is given', async () => {
-      await bandRepository.runTransaction(async tran => {
-        const band = await tran.findById('porcupine-tree');
-        const updatedBand: Partial<Band> = {
-          ...band,
-          contactEmail: 'test@email.com',
-        }
-  
-        await expect(tran.update(updatedBand as Band)).not.to.be.rejected;
+        await tran.update(band);
+        const updatedBand = await tran.findById('porcupine-tree');
+        expect(updatedBand.contactEmail).to.equal('Not an email');
       })
     });
 
@@ -255,8 +220,12 @@ describe('BaseFirestoreTransactionRepository', () => {
         const band = await tran.findById('porcupine-tree');
   
         band.contactEmail = 'Not an email';
-  
-        await expect(tran.update(band)).to.be.rejectedWith(Error);
+
+        try {
+          await tran.update(band);
+        } catch (error) {
+          expect(error[0].constraints.isEmail).to.equal('Invalid email!');
+        }
       })
     });
 
@@ -267,8 +236,12 @@ describe('BaseFirestoreTransactionRepository', () => {
           ...band,
           contactEmail: 'Not an email',
         }
-  
-        await expect(tran.update(updatedBand as Band)).to.be.rejectedWith(Error);
+
+        try {
+          await tran.update(band);
+        } catch (error) {
+          expect(error[0].constraints.isEmail).to.equal('Invalid email!');
+        }
       })
     });
 
@@ -459,7 +432,12 @@ describe('BaseFirestoreTransactionRepository', () => {
 
       await bandRepository.runTransaction(async tran => {
         await tran.create(band);
-        await expect(band.albums.create(firstAlbum)).to.be.rejectedWith(Error, 'failed the validation');
+
+        try {
+          await band.albums.create(firstAlbum);
+        } catch (error) {
+          expect(error[0].constraints.length).to.equal('Name is too long')
+        }
       });
     });
 
@@ -483,7 +461,11 @@ describe('BaseFirestoreTransactionRepository', () => {
         
         album.name = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
 
-        await expect(pt.albums.update(album)).to.be.rejectedWith(Error, 'failed the validation');
+        try {
+          await pt.albums.update(album);
+        } catch (error) {
+          expect(error[0].constraints.length).to.equal('Name is too long');
+        }
       });
     });
 

--- a/src/BaseFirestoreTransactionRepository.ts
+++ b/src/BaseFirestoreTransactionRepository.ts
@@ -45,7 +45,7 @@ export class TransactionRepository<T extends IEntity>
       const errors = await this.validate(item as T);
   
       if (errors.length) {
-        throw new Error(errors.toString());
+        throw errors;
       }
     }
 
@@ -76,7 +76,7 @@ export class TransactionRepository<T extends IEntity>
       const errors = await this.validate(item);
   
       if (errors.length) {
-        throw new Error(errors.toString());
+        throw errors;
       }
     }
 

--- a/src/BaseFirestoreTransactionRepository.ts
+++ b/src/BaseFirestoreTransactionRepository.ts
@@ -11,7 +11,6 @@ import {
   IQueryBuilder,
   IRepository,
   FirestoreCollectionType,
-  InstanstiableIEntity,
 } from './types';
 
 import { AbstractFirestoreRepository } from './AbstractFirestoreRepository';

--- a/src/BaseFirestoreTransactionRepository.ts
+++ b/src/BaseFirestoreTransactionRepository.ts
@@ -22,9 +22,9 @@ export class TransactionRepository<T extends IEntity>
   constructor(
     private collection: CollectionReference,
     private transaction: Transaction,
-    entityConstructor: InstanstiableIEntity
+    colName: string
   ) {
-    super(entityConstructor);
+    super(colName);
   }
 
   execute(queries: IFireOrmQueryLine[]): Promise<T[]> {

--- a/src/Decorators/SubCollection.spec.ts
+++ b/src/Decorators/SubCollection.spec.ts
@@ -11,7 +11,9 @@ describe('SubCollectionDecorator', () => {
   });
 
   it('should register collections', () => {
-    class SubEntity {}
+    class SubEntity {
+      public id: string;
+    }
     class Entity {
       @SubCollection(SubEntity, 'subs')
       readonly subentity: null;
@@ -27,7 +29,9 @@ describe('SubCollectionDecorator', () => {
   });
 
   it('should register collections with default name', () => {
-    class SubEntity {}
+    class SubEntity {
+      public id: string;
+    }
     class Entity {
       @SubCollection(SubEntity)
       readonly subentity: null;

--- a/src/Decorators/SubCollection.ts
+++ b/src/Decorators/SubCollection.ts
@@ -1,8 +1,9 @@
 import { getMetadataStorage } from '../MetadataStorage';
 import { plural } from 'pluralize';
+import { InstanstiableIEntity } from '../types';
 
-export function SubCollection(entity: Function, entityName?: string): Function {
-  return function(target: Function, propertyKey: string) {
+export function SubCollection(entity: InstanstiableIEntity, entityName?: string): Function {
+  return function(target: InstanstiableIEntity, propertyKey: string) {
     getMetadataStorage().setSubCollection({
       entity,
       name: entityName || plural(propertyKey),

--- a/src/MetadataStorage.ts
+++ b/src/MetadataStorage.ts
@@ -18,13 +18,13 @@ export interface CollectionMetadata {
 export interface SubCollectionMetadata {
   parentEntity: Function;
   name: string;
-  entity: Function;
+  entity: InstanstiableIEntity;
   propertyKey: string;
 }
 
 export interface RepositoryMetadata {
   target: Function;
-  entity: Function;
+  entity: InstanstiableIEntity;
 }
 
 export interface MetadataStorageConfig {

--- a/test/BandCollection.ts
+++ b/test/BandCollection.ts
@@ -6,8 +6,7 @@ import {
 } from './fixture';
 import { ISubCollection } from '../src/types';
 import { Type } from '../src';
-import { IsEmail, IsOptional } from 'class-validator';
-import { DocumentReference } from '@google-cloud/firestore';
+import { IsEmail, IsOptional, Length } from 'class-validator';
 
 // Why I do this? Because by using the instance of Album
 // located in fixture.ts, you have the risk to reuse the
@@ -16,7 +15,10 @@ import { DocumentReference } from '@google-cloud/firestore';
 // with each other (happened with getRepository)
 //
 // Hours lost debugging this: 2
-class Album extends AlbumEntity {}
+class Album extends AlbumEntity {
+  @Length(1, 50)
+  name: string;
+}
 
 @Collection('bands')
 export class Band {

--- a/test/BandCollection.ts
+++ b/test/BandCollection.ts
@@ -16,7 +16,9 @@ import { IsEmail, IsOptional, Length } from 'class-validator';
 //
 // Hours lost debugging this: 2
 class Album extends AlbumEntity {
-  @Length(1, 50)
+  @Length(1, 50, {
+    message: 'Name is too long',
+  })
   name: string;
 }
 
@@ -28,7 +30,9 @@ export class Band {
   lastShow: Date;
 
   @IsOptional()
-  @IsEmail()
+  @IsEmail({}, {
+    message: 'Invalid email!',
+  })
   contactEmail?: string;
 
   // Todo create fireorm bypass decorator

--- a/test/setup.unit.ts
+++ b/test/setup.unit.ts
@@ -1,4 +1,0 @@
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-
-chai.use(chaiAsPromised);


### PR DESCRIPTION
Tested out the recent validation feature in a live project and found a few bugs.

Class validator expects a single instance of the package to be installed to collect validation metadata, so it should be a peer dependency to allow FireORM to use the version specified by the user rather than providing our own.

Validation also wasn't working for subcollections, as the parent entity remains the same (and this doesn't have the correct validation decorators on). So I've moved things around to allow for the entity to be found when the `subColName` prop is available.