### PR TITLE
fix: support for array-includes-any and in queries

### DIFF
--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -9,6 +9,7 @@ import {
   IQueryExecutor,
   IEntity,
   IWherePropParam,
+  Filter,
 } from './types';
 
 export default class QueryBuilder<T extends IEntity>
@@ -90,6 +91,30 @@ export default class QueryBuilder<T extends IEntity>
     return this;
   }
 
+  whereArrayContainsAny(
+    prop: IWherePropParam<T>,
+    val: Filter<IFirestoreVal, any[]>
+  ): QueryBuilder<T> {
+    this.queries.push({
+      prop: this.extractWhereParam(prop),
+      val,
+      operator: FirestoreOperators.arrayContainsAny,
+    });
+    return this;
+  }
+
+  whereValueIncludes(
+    prop: IWherePropParam<T>,
+    val: Filter<IFirestoreVal, any[]>
+  ): QueryBuilder<T> {
+    this.queries.push({
+      prop: this.extractWhereParam(prop),
+      val,
+      operator: FirestoreOperators.in,
+    });
+    return this;
+  }
+
   limit(limitVal: number): QueryBuilder<T> {
     if (this.limitVal) {
       throw new Error(
@@ -135,8 +160,13 @@ export default class QueryBuilder<T extends IEntity>
   }
 
   async findOne(): Promise<T | null> {
-    const queryResult = await this.executor.execute(this.queries, this.limitVal, this.orderByObj, true);
-    
+    const queryResult = await this.executor.execute(
+      this.queries,
+      this.limitVal,
+      this.orderByObj,
+      true
+    );
+
     return queryResult.length ? queryResult[0] : null;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import { OrderByDirection, DocumentReference } from '@google-cloud/firestore';
 import { BaseFirestoreRepository } from './BaseFirestoreRepository';
 
 export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+export type Filter<T, U> = T extends U ? T : never;
 
 export interface IRepository<T extends { id: string }> {
   limit(limitVal: number): IQueryBuilder<T>;
@@ -22,6 +23,8 @@ export type WithOptionalId<T extends { id: unknown }> = Pick<
 export type IFirestoreVal =
   | string
   | number
+  | string[]
+  | number[]
   | Date
   | Boolean
   | DocumentReference;
@@ -33,6 +36,8 @@ export enum FirestoreOperators {
   lessThanEqual = '<=',
   greaterThanEqual = '>=',
   arrayContains = 'array-contains',
+  arrayContainsAny = 'array-contains-any',
+  in = 'in',
 }
 
 export enum FirestoreCollectionType {


### PR DESCRIPTION
Initial support for ✨new ✨ queries: `in` and `array-contains-any` [announced on Nov 7](https://firebase.googleblog.com/2019/11/cloud-firestore-now-supports-in-queries.html) 
@wovalle 

TODO:

- [ ] Documentation
- [ ] Integration tests
