### PR TITLE
Batch/transaction support for Subcollections

### DIFF
--- a/src/Batch/FirestoreBatch.ts
+++ b/src/Batch/FirestoreBatch.ts
@@ -21,8 +21,8 @@ export class FirestoreBatch {
    * @returns
    * @memberof FirestoreBatch
    */
-  getRepository<T extends IEntity>(entity: Instantiable<T>) {
-    return new BaseFirestoreBatchRepository(this.batch, entity);
+  getRepository<T extends IEntity>(entity: Instantiable<T>, collectionPath?: string) {
+    return new BaseFirestoreBatchRepository(this.batch, entity, collectionPath);
   }
 
   /**


### PR DESCRIPTION
`getRepository` now accepts a `collectionPath` argument which is used to instantiate the `BaseFirestoreBatchRepository`.

Closes #139