### PR TITLE
feat: adding in and array-contains-any operators support

### DIFF
--- a/src/AbstractFirestoreRepository.ts
+++ b/src/AbstractFirestoreRepository.ts
@@ -203,6 +203,36 @@ export abstract class AbstractFirestoreRepository<T extends IEntity> extends Bas
   }
 
   /**
+   * Returns a new QueryBuilder with a filter specifying that the
+   * field @param prop is an array that contains one or more of the comparison values in @param val
+   *
+   * @param {IWherePropParam<T>} prop field to be filtered on, where
+   * prop could be keyof T or a lambda where T is the first parameter
+   * @param {IFirestoreVal[]} val array of values to compare in the filter (max 10 items in array)
+   * @returns {QueryBuilder<T>} A new QueryBuilder with the specified
+   * query applied.
+   * @memberof AbstractFirestoreRepository
+   */
+  whereArrayContainsAny(prop: IWherePropParam<T>, val: IFirestoreVal[]): IQueryBuilder<T> {
+    return new QueryBuilder<T>(this).whereArrayContainsAny(prop, val);
+  }
+
+  /**
+   * Returns a new QueryBuilder with a filter specifying that the
+   * field @param prop matches any of the comparison values in @param val
+   *
+   * @param {IWherePropParam<T>} prop field to be filtered on, where
+   * prop could be keyof T or a lambda where T is the first parameter
+   * @param {IFirestoreVal[]} val[] array of values to compare in the filter (max 10 items in array)
+   * @returns {QueryBuilder<T>} A new QueryBuilder with the specified
+   * query applied.
+   * @memberof AbstractFirestoreRepository
+   */
+  whereIn(prop: IWherePropParam<T>, val: IFirestoreVal[]): IQueryBuilder<T> {
+    return new QueryBuilder<T>(this).whereIn(prop, val);
+  }
+
+  /**
    * Returns a new QueryBuilder with a maximum number of results
    * to return. Can only be used once per query.
    *

--- a/src/BaseFirestoreRepository.spec.ts
+++ b/src/BaseFirestoreRepository.spec.ts
@@ -389,6 +389,32 @@ describe('BaseFirestoreRepository', () => {
       expect(list.length).toEqual(2);
     });
 
+    it('must filter with whereArrayContainsAny', async () => {
+      const list = await bandRepository
+        .whereArrayContainsAny('genres', ['psychedelic-rock', 'funk-rock'])
+        .find();
+      expect(list.length).toEqual(3);
+    });
+
+    it('must filter with whereIn', async () => {
+      const list = await bandRepository.whereIn('formationYear', [1965, 1983, 1987]).find();
+      expect(list.length).toEqual(3);
+    });
+
+    it('should throw with whereArrayContainsAny and more than 10 items in val array', async () => {
+      expect(async () => {
+        await bandRepository
+          .whereArrayContainsAny('genres', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+          .find();
+      }).rejects.toThrow(Error);
+    });
+
+    it('should throw with whereIn and more than 10 items in val array', async () => {
+      expect(async () => {
+        await bandRepository.whereIn('formationYear', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]).find();
+      }).rejects.toThrow(Error);
+    });
+
     it('must filter with two or more operators', async () => {
       const list = await bandRepository
         .whereLessOrEqualThan('formationYear', 1983)

--- a/src/QueryBuilder.spec.ts
+++ b/src/QueryBuilder.spec.ts
@@ -27,6 +27,14 @@ describe('QueryBuilder', () => {
     expect(executor.queries[0].val).toEqual('1');
   });
 
+  it('must build array value query', async () => {
+    const queryBuilder = new QueryBuilder<Test>(executor);
+    await queryBuilder.whereIn('id', ['1', '2']).find();
+    expect(executor.queries[0].operator).toEqual(FirestoreOperators.in);
+    expect(executor.queries[0].prop).toEqual('id');
+    expect(executor.queries[0].val).toEqual(['1', '2']);
+  });
+
   it('must pipe queries', async () => {
     const queryBuilder = new QueryBuilder<Test>(executor);
     await queryBuilder

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -77,6 +77,36 @@ export default class QueryBuilder<T extends IEntity> implements IQueryBuilder<T>
     return this;
   }
 
+  whereArrayContainsAny(prop: IWherePropParam<T>, val: IFirestoreVal[]): QueryBuilder<T> {
+    if (val.length > 10) {
+      throw new Error(`
+        This query supports up to 10 values. You provided ${val.length}.
+        For details please visit: https://firebase.google.com/docs/firestore/query-data/queries#in_and_array-contains-any
+      `);
+    }
+    this.queries.push({
+      prop: this.extractWhereParam(prop),
+      val,
+      operator: FirestoreOperators.arrayContainsAny,
+    });
+    return this;
+  }
+
+  whereIn(prop: IWherePropParam<T>, val: IFirestoreVal[]): QueryBuilder<T> {
+    if (val.length > 10) {
+      throw new Error(`
+        This query supports up to 10 values. You provided ${val.length}.
+        For details please visit: https://firebase.google.com/docs/firestore/query-data/queries#in_and_array-contains-any
+      `);
+    }
+    this.queries.push({
+      prop: this.extractWhereParam(prop),
+      val,
+      operator: FirestoreOperators.in,
+    });
+    return this;
+  }
+
   limit(limitVal: number): QueryBuilder<T> {
     if (this.limitVal) {
       throw new Error(

--- a/src/Transaction/BaseFirestoreTransactionRepository.spec.ts
+++ b/src/Transaction/BaseFirestoreTransactionRepository.spec.ts
@@ -332,6 +332,38 @@ describe('BaseFirestoreTransactionRepository', () => {
       });
     });
 
+    it('must filter with whereArrayContainsAny', async () => {
+      await bandRepository.runTransaction(async tran => {
+        const list = await tran
+          .whereArrayContainsAny('genres', ['psychedelic-rock', 'funk-rock'])
+          .find();
+        expect(list.length).toEqual(3);
+      });
+    });
+
+    it('must filter with whereIn', async () => {
+      await bandRepository.runTransaction(async tran => {
+        const list = await tran.whereIn('formationYear', [1965, 1983, 1987]).find();
+        expect(list.length).toEqual(3);
+      });
+    });
+
+    it('should throw with whereArrayContainsAny and more than 10 items in val array', async () => {
+      expect(async () => {
+        await bandRepository.runTransaction(async tran => {
+          await tran.whereArrayContainsAny('genres', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]).find();
+        });
+      }).rejects.toThrow(Error);
+    });
+
+    it('should throw with whereIn and more than 10 items in val array', async () => {
+      expect(async () => {
+        await bandRepository.runTransaction(async tran => {
+          await tran.whereIn('formationYear', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]).find();
+        });
+      }).rejects.toThrow(Error);
+    });
+
     it('must filter with two or more operators', async () => {
       await bandRepository.runTransaction(async tran => {
         const list = await tran

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,11 +14,13 @@ export enum FirestoreOperators {
   lessThanEqual = '<=',
   greaterThanEqual = '>=',
   arrayContains = 'array-contains',
+  arrayContainsAny = 'array-contains-any',
+  in = 'in',
 }
 
 export interface IFireOrmQueryLine {
   prop: string;
-  val: IFirestoreVal;
+  val: IFirestoreVal | IFirestoreVal[];
   operator: FirestoreOperators;
 }
 
@@ -38,6 +40,8 @@ export interface IQueryable<T extends IEntity> {
   whereLessThan(prop: IWherePropParam<T>, val: IFirestoreVal): IQueryBuilder<T>;
   whereLessOrEqualThan(prop: IWherePropParam<T>, val: IFirestoreVal): IQueryBuilder<T>;
   whereArrayContains(prop: IWherePropParam<T>, val: IFirestoreVal): IQueryBuilder<T>;
+  whereArrayContainsAny(prop: IWherePropParam<T>, val: IFirestoreVal[]): IQueryBuilder<T>;
+  whereIn(prop: IWherePropParam<T>, val: IFirestoreVal[]): IQueryBuilder<T>;
   find(): Promise<T[]>;
   findOne(): Promise<T | null>;
 }


### PR DESCRIPTION
**Fix for #171**
Added support for missing Firestore operators:
-  `in`  alias `whereIn`
-  `array-contains-any` alias `whereArrayContainsAny`

@wovalle Please check this out, it blocks me with my side project. Thanks in advance