### PR TITLE
Support for create a Firebase Document Reference and offset query

### DIFF
--- a/src/AbstractFirestoreRepository.ts
+++ b/src/AbstractFirestoreRepository.ts
@@ -251,6 +251,24 @@ export abstract class AbstractFirestoreRepository<T extends IEntity> extends Bas
   }
 
   /**
+   * Returns a new QueryBuilder with the offset of the results
+   * to return. Can only be used once per query.
+   *
+   * @param {number} offsetVal number of results to return
+   * Must be greater or equal than 0
+   * @returns {IQueryBuilder<T>} QueryBuilder A new QueryBuilder with
+   * the specified limit applied
+   * @memberof AbstractFirestoreRepository
+   */
+  offset(offsetVal: number): IQueryBuilder<T> {
+    if (offsetVal < 0) {
+      throw new Error(`offsetVal must be greater than 0. It received: ${offsetVal}`);
+    }
+
+    return new QueryBuilder<T>(this).offset(offsetVal);
+  }
+
+  /**
    * Returns a new QueryBuilder with an additional ascending order
    * specified by @param prop. Can only be used once per query.
    *
@@ -349,6 +367,7 @@ export abstract class AbstractFirestoreRepository<T extends IEntity> extends Bas
   abstract execute(
     queries: IFireOrmQueryLine[],
     limitVal?: number,
+    offsetVal?: number,
     orderByObj?: IOrderByParams,
     single?: boolean
   ): Promise<T[]>;

--- a/src/AbstractFirestoreRepository.ts
+++ b/src/AbstractFirestoreRepository.ts
@@ -1,5 +1,5 @@
 import { plainToClass } from 'class-transformer';
-import { DocumentSnapshot, QuerySnapshot } from '@google-cloud/firestore';
+import { DocumentSnapshot, QuerySnapshot, DocumentReference } from '@google-cloud/firestore';
 import { ValidationError } from './Errors/ValidationError';
 
 import {
@@ -397,4 +397,15 @@ export abstract class AbstractFirestoreRepository<T extends IEntity> extends Bas
    * @memberof AbstractFirestoreRepository
    */
   abstract delete(id: string): Promise<void>;
+
+  /**
+   * Return the firestore Document Reference
+   * Must be implemented by base repositores
+   *
+   * @abstract
+   * @param {string} id
+   * @returns {DocumentReference}
+   * @memberof AbstractFirestoreRepository
+   */
+  abstract getReference(id: string): DocumentReference;
 }

--- a/src/BaseFirestoreRepository.ts
+++ b/src/BaseFirestoreRepository.ts
@@ -102,6 +102,7 @@ export class BaseFirestoreRepository<T extends IEntity> extends AbstractFirestor
   async execute(
     queries: Array<IFireOrmQueryLine>,
     limitVal?: number,
+    offsetVal?: number,
     orderByObj?: IOrderByParams,
     single?: boolean
   ): Promise<T[]> {
@@ -118,6 +119,10 @@ export class BaseFirestoreRepository<T extends IEntity> extends AbstractFirestor
       query = query.limit(1);
     } else if (limitVal) {
       query = query.limit(limitVal);
+    }
+
+    if (offsetVal) {
+      query.offset(offsetVal);
     }
 
     return query.get().then(this.extractTFromColSnap);

--- a/src/BaseFirestoreRepository.ts
+++ b/src/BaseFirestoreRepository.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 
-import { CollectionReference, WhereFilterOp } from '@google-cloud/firestore';
+import { CollectionReference, DocumentReference, WhereFilterOp } from '@google-cloud/firestore';
 
 import { IRepository, IFireOrmQueryLine, IOrderByParams, IEntity, Constructor } from './types';
 
@@ -75,6 +75,10 @@ export class BaseFirestoreRepository<T extends IEntity> extends AbstractFirestor
   async delete(id: string): Promise<void> {
     // TODO: handle errors
     await this.firestoreColRef.doc(id).delete();
+  }
+
+  getReference(id: string): DocumentReference {
+    return this.firestoreColRef.doc(id);
   }
 
   async runTransaction<R>(executor: (tran: TransactionRepository<T>) => Promise<R>) {

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -14,6 +14,7 @@ import {
 export default class QueryBuilder<T extends IEntity> implements IQueryBuilder<T> {
   protected queries: Array<IFireOrmQueryLine> = [];
   protected limitVal: number;
+  protected offsetVal: number;
   protected orderByObj: IOrderByParams;
 
   constructor(protected executor: IQueryExecutor<T>) {}
@@ -117,6 +118,16 @@ export default class QueryBuilder<T extends IEntity> implements IQueryBuilder<T>
     return this;
   }
 
+  offset(offsetVal: number): QueryBuilder<T> {
+    if (this.offsetVal) {
+      throw new Error(
+        'A offset function cannot be called more than once in the same query expression'
+      );
+    }
+    this.offsetVal = offsetVal;
+    return this;
+  }
+
   orderByAscending(prop: IWherePropParam<T>): QueryBuilder<T> {
     if (this.orderByObj) {
       throw new Error(
@@ -148,13 +159,14 @@ export default class QueryBuilder<T extends IEntity> implements IQueryBuilder<T>
   }
 
   find(): Promise<T[]> {
-    return this.executor.execute(this.queries, this.limitVal, this.orderByObj);
+    return this.executor.execute(this.queries, this.limitVal, this.offsetVal, this.orderByObj);
   }
 
   async findOne(): Promise<T | null> {
     const queryResult = await this.executor.execute(
       this.queries,
       this.limitVal,
+      this.offsetVal,
       this.orderByObj,
       true
     );

--- a/src/Transaction/BaseFirestoreTransactionRepository.ts
+++ b/src/Transaction/BaseFirestoreTransactionRepository.ts
@@ -1,4 +1,4 @@
-import { CollectionReference, Transaction, WhereFilterOp } from '@google-cloud/firestore';
+import { CollectionReference, Transaction, WhereFilterOp, DocumentReference } from '@google-cloud/firestore';
 
 import {
   IEntity,
@@ -83,6 +83,10 @@ export class TransactionRepository<T extends IEntity> extends AbstractFirestoreR
 
   async delete(id: string): Promise<void> {
     this.transaction.delete(this.firestoreColRef.doc(id));
+  }
+
+  getReference(id: string): DocumentReference {
+    return this.firestoreColRef.doc(id);
   }
 
   limit(): IQueryBuilder<T> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,7 @@ export interface IBaseRepository<T extends IEntity> {
   create(item: PartialBy<T, 'id'>): Promise<T>;
   update(item: T): Promise<T>;
   delete(id: string): Promise<void>;
+  getReference(id: string): DocumentReference;
 }
 
 export type IRepository<T extends IEntity> = IBaseRepository<T> &

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export interface IOrderable<T extends IEntity> {
 
 export interface ILimitable<T extends IEntity> {
   limit(limitVal: number): IQueryBuilder<T>;
+  offset(offsetVal: number): IQueryBuilder<T>;
 }
 
 export type IQueryBuilder<T extends IEntity> = IQueryable<T> & IOrderable<T> & ILimitable<T>;
@@ -61,6 +62,7 @@ export interface IQueryExecutor<T> {
   execute(
     queries: IFireOrmQueryLine[],
     limitVal?: number,
+    offsetVal?: number,
     orderByObj?: IOrderByParams,
     single?: boolean
   ): Promise<T[]>;

--- a/test/functional/6-document-references.int-spec.ts
+++ b/test/functional/6-document-references.int-spec.ts
@@ -60,4 +60,17 @@ describe('Integration test: Using Document References', () => {
     expect(band.length).toEqual(1);
     expect(band[0].name).toEqual('Steven Wilson');
   });
+
+  it('should document reference be the same', async () => {
+    const pt = new Band();
+    pt.id = 'porcupine-tree';
+    pt.name = 'Porcupine Tree';
+    pt.formationYear = 1987;
+    pt.genres = ['psychedelic-rock', 'progressive-rock', 'progressive-metal'];
+
+    await bandRepository.create(pt);
+    const ptRef = firestore.collection(colName).doc(pt.id);
+
+    expect(bandRepository.getReference(pt.id)).toEqual(ptRef);
+  });
 });


### PR DESCRIPTION
Because in my project I need to use document references and the fireorm still doesn't have support for references, both for searching and for creating new documents, I implemented a function to facilitate the manipulation to get a native data of firebase.

I also implemented support for query offset, very useful in document pagination.