### PR TITLE
feat: Adding not-equal and not-in operators support

### DIFF
--- a/src/AbstractFirestoreRepository.ts
+++ b/src/AbstractFirestoreRepository.ts
@@ -248,6 +248,21 @@ export abstract class AbstractFirestoreRepository<T extends IEntity> extends Bas
   }
 
   /**
+   * Returns a new QueryBuilder with a filter specifying that the
+   * field @param prop matches none of the comparison values in @param val
+   *
+   * @param {IWherePropParam<T>} prop field to be filtered on, where
+   * prop could be keyof T or a lambda where T is the first parameter
+   * @param {IFirestoreVal[]} val[] array of values to compare in the filter (max 10 items in array)
+   * @returns {QueryBuilder<T>} A new QueryBuilder with the specified
+   * query applied.
+   * @memberof AbstractFirestoreRepository
+   */
+  whereNotIn(prop: IWherePropParam<T>, val: IFirestoreVal[]): IQueryBuilder<T> {
+    return new QueryBuilder<T>(this).whereNotIn(prop, val);
+  }
+
+  /**
    * Returns a new QueryBuilder with a maximum number of results
    * to return. Can only be used once per query.
    *

--- a/src/AbstractFirestoreRepository.ts
+++ b/src/AbstractFirestoreRepository.ts
@@ -129,6 +129,21 @@ export abstract class AbstractFirestoreRepository<T extends IEntity> extends Bas
 
   /**
    * Returns a new QueryBuilder with a filter specifying that the
+   * value in @param prop must not be equal to @param val.
+   *
+   * @param {IWherePropParam<T>} prop field to be filtered on, where
+   * prop could be keyof T or a lambda where T is the first parameter
+   * @param {IFirestoreVal} val value to compare in the filter
+   * @returns {QueryBuilder<T>} A new QueryBuilder with the specified
+   * query applied.
+   * @memberof AbstractFirestoreRepository
+   */
+  whereNotEqualTo(prop: IWherePropParam<T>, val: IFirestoreVal): IQueryBuilder<T> {
+    return new QueryBuilder<T>(this).whereNotEqualTo(prop, val);
+  }
+
+  /**
+   * Returns a new QueryBuilder with a filter specifying that the
    * value in @param prop must be greater than @param val.
    *
    * @param {IWherePropParam<T>} prop field to be filtered on, where

--- a/src/BaseFirestoreRepository.spec.ts
+++ b/src/BaseFirestoreRepository.spec.ts
@@ -407,6 +407,11 @@ describe('BaseFirestoreRepository', () => {
       expect(list.length).toEqual(3);
     });
 
+    it('must filter with whereNotIn', async () => {
+        const list = await bandRepository.whereNotIn('formationYear', [1965]).find();
+        expect(list.length).toEqual(2);
+    });
+
     it('should throw with whereArrayContainsAny and more than 10 items in val array', async () => {
       expect(async () => {
         await bandRepository
@@ -419,6 +424,12 @@ describe('BaseFirestoreRepository', () => {
       expect(async () => {
         await bandRepository.whereIn('formationYear', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]).find();
       }).rejects.toThrow(Error);
+    });
+
+    it('should throw with whereNotIn and more than 10 items in val array', async () => {
+        expect(async () => {
+          await bandRepository.whereNotIn('formationYear', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]).find();
+        }).rejects.toThrow(Error);
     });
 
     it('must filter with two or more operators', async () => {

--- a/src/BaseFirestoreRepository.spec.ts
+++ b/src/BaseFirestoreRepository.spec.ts
@@ -363,6 +363,12 @@ describe('BaseFirestoreRepository', () => {
       expect(list[0].name).toEqual('Porcupine Tree');
     });
 
+    it('must filter with whereNotEqualTo', async () => {
+        const list = await bandRepository.whereNotEqualTo('name', 'Porcupine Tree').find();
+        expect(list.length).toEqual(1);
+        expect(list[0].formationYear).toEqual(1983);
+      });
+
     it('must filter with whereGreaterThan', async () => {
       const list = await bandRepository.whereGreaterThan('formationYear', 1983).find();
       expect(list.length).toEqual(1);

--- a/src/BaseFirestoreRepository.spec.ts
+++ b/src/BaseFirestoreRepository.spec.ts
@@ -364,10 +364,10 @@ describe('BaseFirestoreRepository', () => {
     });
 
     it('must filter with whereNotEqualTo', async () => {
-        const list = await bandRepository.whereNotEqualTo('name', 'Porcupine Tree').find();
-        expect(list.length).toEqual(1);
-        expect(list[0].formationYear).toEqual(1983);
-      });
+      const list = await bandRepository.whereNotEqualTo('name', 'Porcupine Tree').find();
+      expect(list.length).toEqual(1);
+      expect(list[0].formationYear).toEqual(1983);
+    });
 
     it('must filter with whereGreaterThan', async () => {
       const list = await bandRepository.whereGreaterThan('formationYear', 1983).find();
@@ -408,8 +408,8 @@ describe('BaseFirestoreRepository', () => {
     });
 
     it('must filter with whereNotIn', async () => {
-        const list = await bandRepository.whereNotIn('formationYear', [1965]).find();
-        expect(list.length).toEqual(2);
+      const list = await bandRepository.whereNotIn('formationYear', [1965]).find();
+      expect(list.length).toEqual(2);
     });
 
     it('should throw with whereArrayContainsAny and more than 10 items in val array', async () => {
@@ -427,9 +427,11 @@ describe('BaseFirestoreRepository', () => {
     });
 
     it('should throw with whereNotIn and more than 10 items in val array', async () => {
-        expect(async () => {
-          await bandRepository.whereNotIn('formationYear', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]).find();
-        }).rejects.toThrow(Error);
+      expect(async () => {
+        await bandRepository
+          .whereNotIn('formationYear', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+          .find();
+      }).rejects.toThrow(Error);
     });
 
     it('must filter with two or more operators', async () => {

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -90,7 +90,7 @@ export default class QueryBuilder<T extends IEntity> implements IQueryBuilder<T>
     if (val.length > 10) {
       throw new Error(`
         This query supports up to 10 values. You provided ${val.length}.
-        For details please visit: https://firebase.google.com/docs/firestore/query-data/queries#in_and_array-contains-any
+        For details please visit: https://firebase.google.com/docs/firestore/query-data/queries#in_not-in_and_array-contains-any
       `);
     }
     this.queries.push({
@@ -105,13 +105,28 @@ export default class QueryBuilder<T extends IEntity> implements IQueryBuilder<T>
     if (val.length > 10) {
       throw new Error(`
         This query supports up to 10 values. You provided ${val.length}.
-        For details please visit: https://firebase.google.com/docs/firestore/query-data/queries#in_and_array-contains-any
+        For details please visit: https://firebase.google.com/docs/firestore/query-data/queries#in_not-in_and_array-contains-any
       `);
     }
     this.queries.push({
       prop: this.extractWhereParam(prop),
       val,
       operator: FirestoreOperators.in,
+    });
+    return this;
+  }
+
+  whereNotIn(prop: IWherePropParam<T>, val: IFirestoreVal[]): QueryBuilder<T> {
+    if (val.length > 10) {
+      throw new Error(`
+        This query supports up to 10 values. You provided ${val.length}.
+        For details please visit: https://firebase.google.com/docs/firestore/query-data/queries#in_not-in_and_array-contains-any
+      `);
+    }
+    this.queries.push({
+      prop: this.extractWhereParam(prop),
+      val,
+      operator: FirestoreOperators.notIn,
     });
     return this;
   }

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -32,6 +32,15 @@ export default class QueryBuilder<T extends IEntity> implements IQueryBuilder<T>
     return this;
   }
 
+  whereNotEqualTo(param: IWherePropParam<T>, val: IFirestoreVal): QueryBuilder<T> {
+    this.queries.push({
+      prop: this.extractWhereParam(param),
+      val,
+      operator: FirestoreOperators.notEqual,
+    });
+    return this;
+  }
+
   whereGreaterThan(prop: IWherePropParam<T>, val: IFirestoreVal): QueryBuilder<T> {
     this.queries.push({
       prop: this.extractWhereParam(prop),

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export enum FirestoreOperators {
   arrayContains = 'array-contains',
   arrayContainsAny = 'array-contains-any',
   in = 'in',
+  notIn = 'not-in'
 }
 
 export interface IFireOrmQueryLine {
@@ -45,6 +46,7 @@ export interface IQueryable<T extends IEntity> {
   whereArrayContains(prop: IWherePropParam<T>, val: IFirestoreVal): IQueryBuilder<T>;
   whereArrayContainsAny(prop: IWherePropParam<T>, val: IFirestoreVal[]): IQueryBuilder<T>;
   whereIn(prop: IWherePropParam<T>, val: IFirestoreVal[]): IQueryBuilder<T>;
+  whereNotIn(prop: IWherePropParam<T>, val: IFirestoreVal[]): IQueryBuilder<T>;
   find(): Promise<T[]>;
   findOne(): Promise<T | null>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export type IFirestoreVal = string | number | Date | boolean | DocumentReference
 
 export enum FirestoreOperators {
   equal = '==',
+  notEqual = '!=',
   lessThan = '<',
   greaterThan = '>',
   lessThanEqual = '<=',
@@ -36,6 +37,7 @@ export type IWherePropParam<T> = keyof T | ((t: T) => unknown);
 
 export interface IQueryable<T extends IEntity> {
   whereEqualTo(prop: IWherePropParam<T>, val: IFirestoreVal): IQueryBuilder<T>;
+  whereNotEqualTo(prop: IWherePropParam<T>, val: IFirestoreVal): IQueryBuilder<T>;
   whereGreaterThan(prop: IWherePropParam<T>, val: IFirestoreVal): IQueryBuilder<T>;
   whereGreaterOrEqualThan(prop: IWherePropParam<T>, val: IFirestoreVal): IQueryBuilder<T>;
   whereLessThan(prop: IWherePropParam<T>, val: IFirestoreVal): IQueryBuilder<T>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export enum FirestoreOperators {
   arrayContains = 'array-contains',
   arrayContainsAny = 'array-contains-any',
   in = 'in',
-  notIn = 'not-in'
+  notIn = 'not-in',
 }
 
 export interface IFireOrmQueryLine {


### PR DESCRIPTION
Fix for #205  
Added support for missing Firestore operators:

- `!=` alias `whereNotEqualTo`
- `not-in` alias `whereNotIn`
