### PR TITLE
Feat: snapshot listeners

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,11 +18,16 @@
       "type": "node",
       "request": "launch",
       "name": "Launch current integration test w/ jest",
-      "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/node_modules/.bin/jest", "--runInBand"],
+      "runtimeArgs": [
+        "--inspect-brk",
+        "${workspaceRoot}/node_modules/.bin/jest",
+        "--runInBand",
+        "--testTimeout=60000"
+      ],
       "args": [
         "-c",
         "test/jest.integration.js",
-        "test/functional/4-transactions.spec.ts",
+        "test/functional/8-snapshots.spec.ts",
         "--verbose"
       ],
       "console": "integratedTerminal",

--- a/docgen/Realtime_Updates.md
+++ b/docgen/Realtime_Updates.md
@@ -1,0 +1,44 @@
+# Realtime Updates
+
+Fireorm can subscribe to change to a firestore collection. This is done by the [watch](Classes/BaseFirestoreRepository.md#watch), it receives a callback (listener) and fireorm will pass the entites that were added/changed as the first callback.
+
+```typescript
+const bandSnapshotUnsubscribe = await bandRepository
+  .whereArrayContains(a => a.genres, 'progressive-metal')
+  .watch(bands => {
+    // Will be triggered when any band with progressive-metal genre are added/edited
+  });
+```
+
+## Unsubscribing from updates
+
+The `watch` method of fireorm's [repositories] return an unsubscribe function. When we want to stop listening collection updates we can call this function.
+
+```typescript
+const bandSnapshotUnsubscribe = await bandRepository
+  .whereArrayContains(a => a.genres, 'progressive-metal')
+  .watch(bands => {
+    // Will be triggered when any band with progressive-metal genre are added/edited
+  });
+
+// We no longer need to listen real time updates, so we unsubscribe.
+bandSnapshotUnsubscribe();
+```
+
+## Disabling empty updates
+
+Firestore triggers the listener every single time something is edited in a collection, even though nothing has changed. To skip this, you can pas a `ignoreEmptyUpdate` boolean option to fireorm and it'll skip empty changes. This can option can be passed in the `initialize` (will affect every subscription) or as a second parameter of `watch` (will only affect this subscription).
+
+```typescript
+import { initialize } from 'fireorm';
+
+initialize(firestore, {
+  ignoreEmptyUpdates: true,
+});
+```
+
+```typescript
+const bandSnapshotUnsubscribe = await bandRepository
+  .whereArrayContains(a => a.genres, 'progressive-metal')
+  .watch(handleBandsUpdate, { ignoreEmptyUpdates: true });
+```

--- a/docgen/Validation.md
+++ b/docgen/Validation.md
@@ -1,8 +1,8 @@
 # Validation
 
-FireORM supports [class-validator](https://github.com/typestack/class-validator) validation decorators in any collection.
+Fireorm supports [class-validator](https://github.com/typestack/class-validator) validation decorators in any collection.
 
-As `class-validator` requires a single install per project, FireORM opts not to depend on it explicitly (doing so may result in conflicting versions). It is up to you to install it with `npm i -S class-validator`.
+As `class-validator` requires a single install per project, Fireorm opts not to depend on it explicitly (doing so may result in conflicting versions). It is up to you to install it with `npm i -S class-validator`.
 
 Once installed correctly, you can write your collections like so:
 
@@ -21,10 +21,12 @@ Use this in the same way that you would your other collections and it will valid
 
 ## Disabling validation
 
-Model validation is not enabled by default. It can be enable by initializing FireORM with the `validateModels: true` option.
+Model validation is not enabled by default. It can be enable by initializing Fireorm with the `validateModels: true` option.
 
 ```typescript
+import { initialize } from 'fireorm';
+
 initialize(firestore, {
-  validateModels: true
-})
+  validateModels: true,
+});
 ```

--- a/docgen/sidebar.md
+++ b/docgen/sidebar.md
@@ -12,3 +12,4 @@
   - [Batches](Batches.md)
   - [Custom Repositories](Custom_Repositories.md)
   - [Validation](Validation.md)
+  - [Realtime Updates](Realtime_Updates.md)

--- a/src/AbstractFirestoreRepository.ts
+++ b/src/AbstractFirestoreRepository.ts
@@ -23,7 +23,11 @@ import {
 import { isDocumentReference, isGeoPoint, isObject, isTimestamp } from './TypeGuards';
 
 import { getMetadataStorage } from './MetadataUtils';
-import { MetadataStorageConfig, FullCollectionMetadata } from './MetadataStorage';
+import type {
+  MetadataStorageConfig,
+  FullCollectionMetadata,
+  SnapshotConfig,
+} from './MetadataStorage';
 
 import { BaseRepository } from './BaseRepository';
 import QueryBuilder from './QueryBuilder';
@@ -360,8 +364,8 @@ export abstract class AbstractFirestoreRepository<T extends IEntity> extends Bas
    * @returns {Function} An unsubscribe function that can be called to cancel the snapshot listener
    * @memberof AbstractFirestoreRepository
    */
-  watch(callback: (documents: T[]) => void): Promise<() => void> {
-    return new QueryBuilder<T>(this).watch(callback);
+  watch(callback: (documents: T[]) => void, config?: SnapshotConfig): Promise<() => void> {
+    return new QueryBuilder<T>(this).watch(callback, config);
   }
 
   /**
@@ -384,7 +388,7 @@ export abstract class AbstractFirestoreRepository<T extends IEntity> extends Bas
     } catch (error) {
       if (error.code === 'MODULE_NOT_FOUND') {
         throw new Error(
-          'It looks like class-validator is not installed. Please run `npm i -S class-validator` to fix this error, or initialize FireORM with `validateModels: false` to disable validation.'
+          'It looks like class-validator is not installed. Please run `npm i -S class-validator` to fix this error, or initialize Fireorm with `validateModels: false` to disable validation.'
         );
       }
 
@@ -412,7 +416,10 @@ export abstract class AbstractFirestoreRepository<T extends IEntity> extends Bas
     limitVal?: number,
     orderByObj?: IOrderByParams,
     single?: boolean,
-    onUpdate?: (documents: T[]) => void
+    snapshot?: {
+      onUpdate: (documents: T[]) => void;
+      config?: SnapshotConfig;
+    }
   ): Promise<T[] | (() => void)>;
 
   /**

--- a/src/AbstractFirestoreRepository.ts
+++ b/src/AbstractFirestoreRepository.ts
@@ -355,6 +355,16 @@ export abstract class AbstractFirestoreRepository<T extends IEntity> extends Bas
   }
 
   /**
+   * Execute the query and watch for changes on that query
+   *
+   * @returns {Function} An unsubscribe function that can be called to cancel the snapshot listener
+   * @memberof AbstractFirestoreRepository
+   */
+  watch(callback: (documents: T[]) => void): Promise<() => void> {
+    return new QueryBuilder<T>(this).watch(callback);
+  }
+
+  /**
    * Uses class-validator to validate an entity using decorators set in the collection class
    *
    * @param item class or object representing an entity
@@ -401,8 +411,9 @@ export abstract class AbstractFirestoreRepository<T extends IEntity> extends Bas
     queries: IFireOrmQueryLine[],
     limitVal?: number,
     orderByObj?: IOrderByParams,
-    single?: boolean
-  ): Promise<T[]>;
+    single?: boolean,
+    onUpdate?: (documents: T[]) => void
+  ): Promise<T[] | (() => void)>;
 
   /**
    * Retrieve a document with the specified id.

--- a/src/BaseFirestoreRepository.ts
+++ b/src/BaseFirestoreRepository.ts
@@ -111,12 +111,12 @@ export class BaseFirestoreRepository<T extends IEntity> extends AbstractFirestor
     }
 
     if (onUpdate) {
-      return new Promise((resolve) => {
+      return new Promise(resolve => {
         resolve(
           query.onSnapshot((snapshot: QuerySnapshot) => {
-            return onUpdate(this.extractTFromColSnap(snapshot))
+            return onUpdate(this.extractTFromColSnap(snapshot));
           })
-        )
+        );
       });
     }
     return query.get().then(this.extractTFromColSnap);

--- a/src/Batch/FirestoreBatchUnit.ts
+++ b/src/Batch/FirestoreBatchUnit.ts
@@ -90,7 +90,7 @@ export class FirestoreBatchUnit {
     } catch (error) {
       if (error.code === 'MODULE_NOT_FOUND') {
         throw new Error(
-          'It looks like class-validator is not installed. Please run `npm i -S class-validator` to fix this error, or initialize FireORM with `validateModels: false` to disable validation.'
+          'It looks like class-validator is not installed. Please run `npm i -S class-validator` to fix this error, or initialize Fireorm with `validateModels: false` to disable validation.'
         );
       }
 

--- a/src/MetadataStorage.ts
+++ b/src/MetadataStorage.ts
@@ -30,9 +30,14 @@ export interface RepositoryMetadata {
   entity: IEntityConstructor;
 }
 
-export interface MetadataStorageConfig {
+export interface SnapshotConfig {
+  ignoreEmptyUpdates: boolean;
+}
+export interface ValidationConfig {
   validateModels: boolean;
 }
+
+export type MetadataStorageConfig = SnapshotConfig & ValidationConfig;
 
 export class MetadataStorage {
   readonly collections: Array<CollectionMetadataWithSegments> = [];
@@ -40,6 +45,7 @@ export class MetadataStorage {
 
   public config: MetadataStorageConfig = {
     validateModels: false,
+    ignoreEmptyUpdates: false,
   };
 
   public getCollection = (pathOrConstructor: string | IEntityConstructor) => {

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -171,17 +171,27 @@ export default class QueryBuilder<T extends IEntity> implements IQueryBuilder<T>
     return this;
   }
 
-  find() {
-    return this.executor.execute(this.queries, this.limitVal, this.orderByObj);
+  find(): Promise<T[]> {
+    return this.executor.execute(this.queries, this.limitVal, this.orderByObj) as Promise<T[]>;
   }
 
-  async findOne() {
+  watch(callback: (documents: T[]) => void) {
+    return this.executor.execute(
+      this.queries,
+      this.limitVal,
+      this.orderByObj,
+      false,
+      callback
+    ) as Promise<() => void>;
+  }
+
+  async findOne(): Promise<T | null> {
     const queryResult = await this.executor.execute(
       this.queries,
       this.limitVal,
       this.orderByObj,
       true
-    );
+    ) as T[];
 
     return queryResult.length ? queryResult[0] : null;
   }

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -186,12 +186,12 @@ export default class QueryBuilder<T extends IEntity> implements IQueryBuilder<T>
   }
 
   async findOne(): Promise<T | null> {
-    const queryResult = await this.executor.execute(
+    const queryResult = (await this.executor.execute(
       this.queries,
       this.limitVal,
       this.orderByObj,
       true
-    ) as T[];
+    )) as T[];
 
     return queryResult.length ? queryResult[0] : null;
   }

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -1,4 +1,5 @@
 import { getPath } from 'ts-object-path';
+import type { SnapshotConfig } from './MetadataStorage';
 
 import {
   IQueryBuilder,
@@ -175,14 +176,11 @@ export default class QueryBuilder<T extends IEntity> implements IQueryBuilder<T>
     return this.executor.execute(this.queries, this.limitVal, this.orderByObj) as Promise<T[]>;
   }
 
-  watch(callback: (documents: T[]) => void) {
-    return this.executor.execute(
-      this.queries,
-      this.limitVal,
-      this.orderByObj,
-      false,
-      callback
-    ) as Promise<() => void>;
+  watch(onUpdate: (documents: T[]) => void, config?: SnapshotConfig) {
+    return this.executor.execute(this.queries, this.limitVal, this.orderByObj, false, {
+      onUpdate,
+      config,
+    }) as Promise<() => void>;
   }
 
   async findOne(): Promise<T | null> {

--- a/src/Transaction/BaseFirestoreTransactionRepository.ts
+++ b/src/Transaction/BaseFirestoreTransactionRepository.ts
@@ -23,7 +23,7 @@ export class TransactionRepository<T extends IEntity> extends AbstractFirestoreR
     this.tranRefStorage = tranRefStorage;
   }
 
-  async execute(queries: IFireOrmQueryLine[]): Promise<T[]> {
+  async execute(queries: IFireOrmQueryLine[]): Promise<T[] | (() => void)> {
     const query = queries.reduce<Query>((acc, cur) => {
       const op = cur.operator as WhereFilterOp;
       return acc.where(cur.prop, op, cur.val);

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export interface IQueryable<T extends IEntity> {
   whereNotIn(prop: IWherePropParam<T>, val: IFirestoreVal[]): IQueryBuilder<T>;
   find(): Promise<T[]>;
   findOne(): Promise<T | null>;
+  watch(handler: (documents: T[]) => void): Promise<() => void>;
 }
 
 export interface IOrderable<T extends IEntity> {
@@ -67,8 +68,9 @@ export interface IQueryExecutor<T> {
     queries: IFireOrmQueryLine[],
     limitVal?: number,
     orderByObj?: IOrderByParams,
-    single?: boolean
-  ): Promise<T[]>;
+    single?: boolean,
+    onUpdate?: (documents: T[]) => void
+  ): Promise<T[] | (() => void)>;
 }
 
 export interface IBatchRepository<T extends IEntity> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { OrderByDirection, DocumentReference } from '@google-cloud/firestore';
+import type { SnapshotConfig } from './MetadataStorage';
 
 export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 export type PartialWithRequiredBy<T, K extends keyof T> = Pick<T, K> & Partial<Omit<T, K>>;
@@ -49,7 +50,7 @@ export interface IQueryable<T extends IEntity> {
   whereNotIn(prop: IWherePropParam<T>, val: IFirestoreVal[]): IQueryBuilder<T>;
   find(): Promise<T[]>;
   findOne(): Promise<T | null>;
-  watch(handler: (documents: T[]) => void): Promise<() => void>;
+  watch(handler: (documents: T[]) => void, config?: SnapshotConfig): Promise<() => void>;
 }
 
 export interface IOrderable<T extends IEntity> {
@@ -69,7 +70,10 @@ export interface IQueryExecutor<T> {
     limitVal?: number,
     orderByObj?: IOrderByParams,
     single?: boolean,
-    onUpdate?: (documents: T[]) => void
+    snapshot?: {
+      onUpdate: (documents: T[]) => void;
+      config?: SnapshotConfig;
+    }
   ): Promise<T[] | (() => void)>;
 }
 

--- a/test/functional/8-snapshots.spec.ts
+++ b/test/functional/8-snapshots.spec.ts
@@ -9,31 +9,30 @@ describe('Integration test: Simple Repository', () => {
   }
 
   test('should do crud operations', async () => {
-
     const bandRepository = getRepository(Band);
 
     // Create snapshot listener
-    let executionIndex = 1
+    let executionIndex = 1;
     const handleBandsUpdate = (bands: Band[]) => {
       if (!bands.length) {
-        return
+        return;
       }
       if (executionIndex == 1) {
         expect(bands.length).toEqual(1);
-      }
-      else if (executionIndex == 2) {
+      } else if (executionIndex == 2) {
         expect(bands.length).toEqual(2);
-      }
-      else if (executionIndex == 3) {
+      } else if (executionIndex == 3) {
         expect(bands.length).toEqual(2);
-        bands.forEach((band) => {
+
+        bands.forEach(band => {
           if (band.id == 'dream-theatre') {
             expect(band.name).toEqual('Dream Theatre');
           }
-        })
+        });
       }
       executionIndex++;
-    }
+    };
+
     const bandSnapshotUnsubscribe = await bandRepository
       .whereEqualTo(a => a.extra.website, 'www.dreamtheater.net')
       .watch(handleBandsUpdate);
@@ -47,9 +46,11 @@ describe('Integration test: Simple Repository', () => {
     dt.extra = {
       website: 'www.dreamtheater.net',
     };
-    const savedBand = await bandRepository.create(dt);
 
-    // Create a band without an id  (execution 2)
+    // First execution
+    await bandRepository.create(dt);
+
+    // Create a band without an id (second execution)
     const devinT = new Band();
     devinT.name = 'Devin Townsend Project';
     devinT.formationYear = 2009;
@@ -57,15 +58,16 @@ describe('Integration test: Simple Repository', () => {
     devinT.extra = {
       website: 'www.dreamtheater.net',
     };
-    const savedBandWithoutId = await bandRepository.create(devinT);
 
-    // Update a band (execution 3)
+    // Third Execution
+    await bandRepository.create(devinT);
+
+    // Update a band (fourth execution)
     dt.name = 'Dream Theater';
-    const updatedDt = await bandRepository.update(dt);
-    const updatedDtInDb = await bandRepository.findById(dt.id);
+    await bandRepository.update(dt);
+    await bandRepository.findById(dt.id);
 
     // Unsubscribe from snapshot
     bandSnapshotUnsubscribe();
-    
   });
 });

--- a/test/functional/8-snapshots.spec.ts
+++ b/test/functional/8-snapshots.spec.ts
@@ -14,9 +14,6 @@ describe('Integration test: Simple Repository', () => {
     // Create snapshot listener
     let executionIndex = 1;
     const handleBandsUpdate = (bands: Band[]) => {
-      if (!bands.length) {
-        return;
-      }
       if (executionIndex == 1) {
         expect(bands.length).toEqual(1);
       } else if (executionIndex == 2) {
@@ -25,7 +22,7 @@ describe('Integration test: Simple Repository', () => {
         expect(bands.length).toEqual(2);
 
         bands.forEach(band => {
-          if (band.id == 'dream-theatre') {
+          if (band.id == 'dream-theater') {
             expect(band.name).toEqual('Dream Theatre');
           }
         });
@@ -34,38 +31,42 @@ describe('Integration test: Simple Repository', () => {
     };
 
     const bandSnapshotUnsubscribe = await bandRepository
-      .whereEqualTo(a => a.extra.website, 'www.dreamtheater.net')
-      .watch(handleBandsUpdate);
+      .whereArrayContains(a => a.genres, 'progressive-metal')
+      .watch(handleBandsUpdate, { ignoreEmptyUpdates: true });
 
-    // Create a band (execution 1)
-    const dt = new Band();
-    dt.id = 'dream-theater';
-    dt.name = 'DreamTheater';
-    dt.formationYear = 1985;
-    dt.genres = ['progressive-metal', 'progressive-rock'];
-    dt.extra = {
-      website: 'www.dreamtheater.net',
+    const dt = {
+      id: 'dream-theater',
+      name: 'DreamTheater',
+      formationYear: 1985,
+      genres: ['progressive-metal', 'progressive-rock'],
+      lastShow: null,
     };
 
     // First execution
     await bandRepository.create(dt);
 
-    // Create a band without an id (second execution)
-    const devinT = new Band();
-    devinT.name = 'Devin Townsend Project';
-    devinT.formationYear = 2009;
-    devinT.genres = ['progressive-metal', 'extreme-metal'];
-    devinT.extra = {
-      website: 'www.dreamtheater.net',
-    };
+    // Second execution
+    await bandRepository.create({
+      name: 'Devin Townsend Project',
+      formationYear: 2009,
+      genres: ['progressive-metal', 'extreme-metal'],
+      lastShow: null,
+    });
 
-    // Third Execution
-    await bandRepository.create(devinT);
+    // Third execution
+    await bandRepository.create({
+      id: 'porcupine-tree',
+      name: 'Porcupine Tree',
+      formationYear: 2009,
+      genres: ['psychedelic-rock', 'progressive-rock', 'progressive-metal'],
+      lastShow: null,
+    });
 
     // Update a band (fourth execution)
     dt.name = 'Dream Theater';
+
+    // Fourth execution
     await bandRepository.update(dt);
-    await bandRepository.findById(dt.id);
 
     // Unsubscribe from snapshot
     bandSnapshotUnsubscribe();

--- a/test/functional/8-snapshots.spec.ts
+++ b/test/functional/8-snapshots.spec.ts
@@ -1,0 +1,71 @@
+import { getRepository, Collection } from '../../src';
+import { Band as BandEntity } from '../fixture';
+import { getUniqueColName } from '../setup';
+
+describe('Integration test: Simple Repository', () => {
+  @Collection(getUniqueColName('band-snapshot-repository'))
+  class Band extends BandEntity {
+    extra?: { website: string };
+  }
+
+  test('should do crud operations', async () => {
+
+    const bandRepository = getRepository(Band);
+
+    // Create snapshot listener
+    let executionIndex = 1
+    const handleBandsUpdate = (bands: Band[]) => {
+      if (!bands.length) {
+        return
+      }
+      if (executionIndex == 1) {
+        expect(bands.length).toEqual(1);
+      }
+      else if (executionIndex == 2) {
+        expect(bands.length).toEqual(2);
+      }
+      else if (executionIndex == 3) {
+        expect(bands.length).toEqual(2);
+        bands.forEach((band) => {
+          if (band.id == 'dream-theatre') {
+            expect(band.name).toEqual('Dream Theatre');
+          }
+        })
+      }
+      executionIndex++;
+    }
+    const bandSnapshotUnsubscribe = await bandRepository
+      .whereEqualTo(a => a.extra.website, 'www.dreamtheater.net')
+      .watch(handleBandsUpdate);
+
+    // Create a band (execution 1)
+    const dt = new Band();
+    dt.id = 'dream-theater';
+    dt.name = 'DreamTheater';
+    dt.formationYear = 1985;
+    dt.genres = ['progressive-metal', 'progressive-rock'];
+    dt.extra = {
+      website: 'www.dreamtheater.net',
+    };
+    const savedBand = await bandRepository.create(dt);
+
+    // Create a band without an id  (execution 2)
+    const devinT = new Band();
+    devinT.name = 'Devin Townsend Project';
+    devinT.formationYear = 2009;
+    devinT.genres = ['progressive-metal', 'extreme-metal'];
+    devinT.extra = {
+      website: 'www.dreamtheater.net',
+    };
+    const savedBandWithoutId = await bandRepository.create(devinT);
+
+    // Update a band (execution 3)
+    dt.name = 'Dream Theater';
+    const updatedDt = await bandRepository.update(dt);
+    const updatedDtInDb = await bandRepository.findById(dt.id);
+
+    // Unsubscribe from snapshot
+    bandSnapshotUnsubscribe();
+    
+  });
+});


### PR DESCRIPTION
Still missing:

- Revisit documentation
- Add missing unit tests (like ignoreEmptyUpdates)
- Add the ability to listen changes in entities (not only collections)
- Return docChanges to the user (maybe as the second param of the watch callback?)