### PR TITLE
fix: prevent default exports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,13 @@ module.exports = {
         '@typescript-eslint/interface-name-prefix': 'off',
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector: 'ExportDefaultDeclaration',
+            message: 'Prefer named exports',
+          },
+        ],
       },
     },
     {

--- a/src/AbstractFirestoreRepository.ts
+++ b/src/AbstractFirestoreRepository.ts
@@ -26,7 +26,7 @@ import { getMetadataStorage } from './MetadataUtils';
 import { MetadataStorageConfig, FullCollectionMetadata } from './MetadataStorage';
 
 import { BaseRepository } from './BaseRepository';
-import QueryBuilder from './QueryBuilder';
+import { QueryBuilder } from './QueryBuilder';
 import { serializeEntity } from './utils';
 import { NoMetadataError } from './Errors';
 

--- a/src/QueryBuilder.spec.ts
+++ b/src/QueryBuilder.spec.ts
@@ -1,4 +1,4 @@
-import QueryBuilder from './QueryBuilder';
+import { QueryBuilder } from './QueryBuilder';
 import { IQueryExecutor, IFireOrmQueryLine, FirestoreOperators } from './types';
 class Test {
   id: string;

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -11,7 +11,7 @@ import {
   IWherePropParam,
 } from './types';
 
-export default class QueryBuilder<T extends IEntity> implements IQueryBuilder<T> {
+export class QueryBuilder<T extends IEntity> implements IQueryBuilder<T> {
   protected queries: Array<IFireOrmQueryLine> = [];
   protected limitVal: number;
   protected orderByObj: IOrderByParams;


### PR DESCRIPTION
default exports are not supported by typescript Module Augmentation,
this simple fix allows for patching in fixes like in the example [here](https://github.com/wovalle/fireorm/issues/244#issue-847449663).