### PR TITLE
feat: Custom query escape hatch

### DIFF
--- a/src/AbstractFirestoreRepository.ts
+++ b/src/AbstractFirestoreRepository.ts
@@ -18,6 +18,7 @@ import {
   PartialBy,
   IEntityConstructor,
   ITransactionReferenceStorage,
+  ICustomQuery,
 } from './types';
 
 import { isDocumentReference, isGeoPoint, isObject, isTimestamp } from './TypeGuards';
@@ -401,7 +402,8 @@ export abstract class AbstractFirestoreRepository<T extends IEntity> extends Bas
     queries: IFireOrmQueryLine[],
     limitVal?: number,
     orderByObj?: IOrderByParams,
-    single?: boolean
+    single?: boolean,
+    customQuery?: ICustomQuery<T>
   ): Promise<T[]>;
 
   /**

--- a/src/AbstractFirestoreRepository.ts
+++ b/src/AbstractFirestoreRepository.ts
@@ -356,6 +356,19 @@ export abstract class AbstractFirestoreRepository<T extends IEntity> extends Bas
   }
 
   /**
+   * Returns a new QueryBuilder with an custom query
+   * specified by @param func. Can only be used once per query.
+   *
+   * @param {ICustomQuery<T>} func function to run in a new query
+   * @returns {QueryBuilder<T>} A new QueryBuilder with the specified
+   * custom query applied.
+   * @memberof AbstractFirestoreRepository
+   */
+  customQuery(func: ICustomQuery<T>) {
+    return new QueryBuilder<T>(this).customQuery(func)
+  }
+
+  /**
    * Uses class-validator to validate an entity using decorators set in the collection class
    *
    * @param item class or object representing an entity

--- a/src/AbstractFirestoreRepository.ts
+++ b/src/AbstractFirestoreRepository.ts
@@ -364,8 +364,8 @@ export abstract class AbstractFirestoreRepository<T extends IEntity> extends Bas
    * custom query applied.
    * @memberof AbstractFirestoreRepository
    */
-  customQuery(func: ICustomQuery<T>) {
-    return new QueryBuilder<T>(this).customQuery(func)
+  customQuery(func: ICustomQuery<T>): IQueryBuilder<T> {
+    return new QueryBuilder<T>(this).customQuery(func);
   }
 
   /**

--- a/src/BaseFirestoreRepository.ts
+++ b/src/BaseFirestoreRepository.ts
@@ -9,6 +9,7 @@ import {
   IEntity,
   PartialBy,
   ITransactionRepository,
+  ICustomQuery,
 } from './types';
 
 import { getMetadataStorage } from './MetadataUtils';
@@ -91,7 +92,8 @@ export class BaseFirestoreRepository<T extends IEntity> extends AbstractFirestor
     queries: Array<IFireOrmQueryLine>,
     limitVal?: number,
     orderByObj?: IOrderByParams,
-    single?: boolean
+    single?: boolean,
+    customQuery?: ICustomQuery<T>
   ): Promise<T[]> {
     let query = queries.reduce<Query>((acc, cur) => {
       const op = cur.operator as WhereFilterOp;
@@ -106,6 +108,10 @@ export class BaseFirestoreRepository<T extends IEntity> extends AbstractFirestor
       query = query.limit(1);
     } else if (limitVal) {
       query = query.limit(limitVal);
+    }
+
+    if (customQuery) {
+      query = await customQuery(query, this.firestoreColRef);
     }
 
     return query.get().then(this.extractTFromColSnap);

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -9,12 +9,14 @@ import {
   IQueryExecutor,
   IEntity,
   IWherePropParam,
+  ICustomQuery,
 } from './types';
 
 export default class QueryBuilder<T extends IEntity> implements IQueryBuilder<T> {
   protected queries: Array<IFireOrmQueryLine> = [];
   protected limitVal: number;
   protected orderByObj: IOrderByParams;
+  protected customQueryFunction?: ICustomQuery<T>;
 
   constructor(protected executor: IQueryExecutor<T>) {}
 
@@ -172,7 +174,20 @@ export default class QueryBuilder<T extends IEntity> implements IQueryBuilder<T>
   }
 
   find() {
-    return this.executor.execute(this.queries, this.limitVal, this.orderByObj);
+    return this.executor.execute(
+      this.queries,
+      this.limitVal,
+      this.orderByObj,
+      false,
+      this.customQueryFunction
+    );
+  }
+
+  customQuery(func: ICustomQuery<T>) {
+    if (this.customQueryFunction) {
+      throw new Error('Only one custom query can be used per query expression');
+    }
+    this.customQueryFunction = func;
   }
 
   async findOne() {
@@ -180,7 +195,8 @@ export default class QueryBuilder<T extends IEntity> implements IQueryBuilder<T>
       this.queries,
       this.limitVal,
       this.orderByObj,
-      true
+      true,
+      this.customQueryFunction
     );
 
     return queryResult.length ? queryResult[0] : null;

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -187,7 +187,10 @@ export default class QueryBuilder<T extends IEntity> implements IQueryBuilder<T>
     if (this.customQueryFunction) {
       throw new Error('Only one custom query can be used per query expression');
     }
+
     this.customQueryFunction = func;
+
+    return this;
   }
 
   async findOne() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export interface IQueryable<T extends IEntity> {
   whereNotIn(prop: IWherePropParam<T>, val: IFirestoreVal[]): IQueryBuilder<T>;
   find(): Promise<T[]>;
   findOne(): Promise<T | null>;
+  customQuery(func: ICustomQuery<T>): IQueryBuilder<T>;
 }
 
 export interface IOrderable<T extends IEntity> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
-import { OrderByDirection, DocumentReference } from '@google-cloud/firestore';
+import { OrderByDirection, DocumentReference, CollectionReference } from '@google-cloud/firestore';
+import { Query } from '@google-cloud/firestore';
 
 export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 export type PartialWithRequiredBy<T, K extends keyof T> = Pick<T, K> & Partial<Omit<T, K>>;
@@ -62,12 +63,18 @@ export interface ILimitable<T extends IEntity> {
 
 export type IQueryBuilder<T extends IEntity> = IQueryable<T> & IOrderable<T> & ILimitable<T>;
 
+export type ICustomQuery<T> = (
+  query: Query,
+  firestoreColRef: CollectionReference
+) => Promise<Query>;
+
 export interface IQueryExecutor<T> {
   execute(
     queries: IFireOrmQueryLine[],
     limitVal?: number,
     orderByObj?: IOrderByParams,
-    single?: boolean
+    single?: boolean,
+    customQuery?: ICustomQuery<T>
   ): Promise<T[]>;
 }
 


### PR DESCRIPTION
Add an escape hatch to have access to the underlying firebase query.

This is a good way to leave the door open to unsupported features in FireORM.

Similar implementation but with local moneypatching here: https://github.com/wovalle/fireorm/issues/244#issue-847449663

Example for usage here: https://github.com/wovalle/fireorm/issues/244#issuecomment-811512104