### PR TITLE
feat: do not store properties decorated with @Ignore() decorator

### DIFF
--- a/src/Decorators/Ignore.spec.ts
+++ b/src/Decorators/Ignore.spec.ts
@@ -1,0 +1,17 @@
+import { Ignore, ignoreKey } from './Ignore';
+
+describe('IgnoreDecorator', () => {
+  it('should decorate properties', () => {
+    class Band {
+      id: string;
+      foo: string;
+      @Ignore()
+      bar: string;
+    }
+
+    const band = new Band();
+
+    expect(Reflect.getMetadata(ignoreKey, band, 'foo')).toBe(undefined);
+    expect(Reflect.getMetadata(ignoreKey, band, 'bar')).toBe(true);
+  });
+});

--- a/src/Decorators/Ignore.ts
+++ b/src/Decorators/Ignore.ts
@@ -1,0 +1,6 @@
+import 'reflect-metadata';
+export const ignoreKey = Symbol('Ignore');
+
+export function Ignore() {
+  return Reflect.metadata(ignoreKey, true);
+}

--- a/src/Decorators/index.ts
+++ b/src/Decorators/index.ts
@@ -1,3 +1,4 @@
 export * from './Collection';
 export * from './CustomRepository';
 export * from './SubCollection';
+export * from './Ignore';

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,4 +1,6 @@
-import { extractAllGetters } from './utils';
+import { Ignore } from './Decorators/Ignore';
+import { IEntity } from './types';
+import { extractAllGetters, serializeEntity } from './utils';
 
 describe('Utils', () => {
   describe('extractAllGetter', () => {
@@ -54,6 +56,24 @@ describe('Utils', () => {
 
       const extracted = extractAllGetters((b as unknown) as Record<string, unknown>);
       expect(extracted).toEqual({ b: 'b' });
+    });
+  });
+
+  describe('serializeEntity', () => {
+    it('should not return properties with an Ignore() decorator', () => {
+      class Band implements IEntity {
+        id: string;
+        name: string;
+        @Ignore()
+        temporaryName: string;
+      }
+
+      const rhcp = new Band();
+      rhcp.name = 'Red Hot Chili Peppers';
+      rhcp.temporaryName = 'Tony Flow and the Miraculously Majestic Masters of Mayhem';
+
+      expect(serializeEntity(rhcp, [])).toHaveProperty('name');
+      expect(serializeEntity(rhcp, [])).not.toHaveProperty('temporaryName');
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { ignoreKey } from './Decorators/Ignore';
 import { SubCollectionMetadata } from './MetadataStorage';
 import { IEntity } from '.';
 
@@ -53,6 +54,13 @@ export function serializeEntity<T extends IEntity>(
   subColMetadata.forEach(scm => {
     delete serializableObj[scm.propertyKey];
   });
+
+  Object.keys(obj).forEach(propertyKey => {
+    if (Reflect.getMetadata(ignoreKey, obj, propertyKey) === true) {
+      delete serializableObj[propertyKey];
+    }
+  });
+
   return serializableObj;
 }
 

--- a/test/functional/8-ignore-properties.spec.ts
+++ b/test/functional/8-ignore-properties.spec.ts
@@ -1,0 +1,28 @@
+import { Collection, getRepository, Ignore } from '../../src';
+import { Band as BandEntity } from '../fixture';
+import { getUniqueColName } from '../setup';
+
+describe('Integration test: Ignore Properties', () => {
+  @Collection(getUniqueColName('band-simple-repository'))
+  class Band extends BandEntity {
+    @Ignore()
+    temporaryName: string;
+  }
+
+  test('should ignore properties decorated with Ignore()', async () => {
+    const bandRepository = getRepository(Band);
+    // Create a band
+    const dt = new Band();
+    dt.id = 'dream-theater';
+    dt.name = 'DreamTheater';
+    dt.temporaryName = 'Drömteater';
+
+    await bandRepository.create(dt);
+
+    // Read a band
+    const foundBand = await bandRepository.findById(dt.id);
+    expect(foundBand.id).toEqual(dt.id);
+    expect(foundBand.name).toEqual(dt.name);
+    expect(foundBand).not.toHaveProperty('temporaryName');
+  });
+});


### PR DESCRIPTION
New decorator allows for entities to have properties that are not stored.