### PR TITLE
fix: A bug fix, issue 266

### DIFF
--- a/src/BaseFirestoreRepository.spec.ts
+++ b/src/BaseFirestoreRepository.spec.ts
@@ -126,7 +126,16 @@ describe('BaseFirestoreRepository', () => {
           albumsSubColl.orderByAscending('releaseDate').orderByDescending('releaseDate');
         }).toThrow();
       });
+
+      it('must succeed when orderBy* function is called more than once in the same expression with different fields', async () => {
+        const pt = await bandRepository.findById('porcupine-tree');
+        const albumsSubColl = pt.albums;
+        expect(() => {
+          albumsSubColl.orderByAscending('releaseDate').orderByDescending('name');
+        }).toBeTruthy();
+      });
     });
+  });
 
     describe('orderByDescending', () => {
       it('must order repository objects', async () => {
@@ -164,8 +173,15 @@ describe('BaseFirestoreRepository', () => {
           albumsSubColl.orderByAscending('releaseDate').orderByDescending('releaseDate');
         }).toThrow();
       });
+
+      it('must succeed when orderBy* function is called more than once in the same expression with different fields', async () => {
+        const pt = await bandRepository.findById('porcupine-tree');
+        const albumsSubColl = pt.albums;
+        expect(() => {
+          albumsSubColl.orderByAscending('releaseDate').orderByDescending('name');
+        }).toBeTruthy();
+      });
     });
-  });
 
   describe('findById', () => {
     it('must find by id', async () => {

--- a/src/BaseFirestoreRepository.spec.ts
+++ b/src/BaseFirestoreRepository.spec.ts
@@ -127,12 +127,20 @@ describe('BaseFirestoreRepository', () => {
         }).toThrow();
       });
 
+      it('must throw an Error if an orderBy* function is called more than once in the same expression ascending', async () => {
+        const pt = await bandRepository.findById('porcupine-tree');
+        const albumsSubColl = pt.albums;
+        expect(() => {
+          albumsSubColl.orderByAscending('releaseDate').orderByAscending('releaseDate');
+        }).toThrow();
+      });
+
       it('must succeed when orderBy* function is called more than once in the same expression with different fields', async () => {
         const pt = await bandRepository.findById('porcupine-tree');
         const albumsSubColl = pt.albums;
         expect(() => {
           albumsSubColl.orderByAscending('releaseDate').orderByDescending('name');
-        }).toBeTruthy();
+        }).not.toThrow();
       });
     });
   });
@@ -174,12 +182,36 @@ describe('BaseFirestoreRepository', () => {
         }).toThrow();
       });
 
+      it('must throw an Error if an orderBy* function is called more than once in the same expression descending', async () => {
+        const pt = await bandRepository.findById('porcupine-tree');
+        const albumsSubColl = pt.albums;
+        expect(() => {
+          albumsSubColl.orderByDescending('releaseDate').orderByDescending('releaseDate');
+        }).toThrow();
+      });
+
       it('must succeed when orderBy* function is called more than once in the same expression with different fields', async () => {
         const pt = await bandRepository.findById('porcupine-tree');
         const albumsSubColl = pt.albums;
         expect(() => {
           albumsSubColl.orderByAscending('releaseDate').orderByDescending('name');
-        }).toBeTruthy();
+        }).not.toThrow();
+      });
+
+      it('must succeed when orderBy* function is called more than once in the same expression with different fields ascending', async () => {
+        const pt = await bandRepository.findById('porcupine-tree');
+        const albumsSubColl = pt.albums;
+        expect(() => {
+          albumsSubColl.orderByAscending('releaseDate').orderByAscending('name');
+        }).not.toThrow();
+      });
+
+      it('must succeed when orderBy* function is called more than once in the same expression with different fields descending', async () => {
+        const pt = await bandRepository.findById('porcupine-tree');
+        const albumsSubColl = pt.albums;
+        expect(() => {
+          albumsSubColl.orderByDescending('releaseDate').orderByDescending('name');
+        }).not.toThrow();
       });
     });
 

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -17,6 +17,7 @@ export class QueryBuilder<T extends IEntity> implements IQueryBuilder<T> {
   protected limitVal: number;
   protected orderByObj: IOrderByParams;
   protected customQueryFunction?: ICustomQuery<T>;
+  protected orderByFields: Set<string> = new Set();
 
   constructor(protected executor: IQueryExecutor<T>) {}
 
@@ -144,10 +145,17 @@ export class QueryBuilder<T extends IEntity> implements IQueryBuilder<T> {
   }
 
   orderByAscending(prop: IWherePropParam<T>) {
-    if (this.orderByObj) {
+    const fieldProp: string = typeof prop == 'string' ? prop : '';
+    const alreadyOrderedByField = this.orderByFields.has(fieldProp);
+
+    if (this.orderByObj && alreadyOrderedByField) {
       throw new Error(
         'An orderBy function cannot be called more than once in the same query expression'
       );
+    }
+
+    if (!alreadyOrderedByField && fieldProp) {
+      this.orderByFields.add(fieldProp);
     }
 
     this.orderByObj = {
@@ -159,10 +167,17 @@ export class QueryBuilder<T extends IEntity> implements IQueryBuilder<T> {
   }
 
   orderByDescending(prop: IWherePropParam<T>) {
-    if (this.orderByObj) {
+    const fieldProp: string = typeof prop == 'string' ? prop : '';
+    const alreadyOrderedByField = this.orderByFields.has(fieldProp);
+
+    if (this.orderByObj && alreadyOrderedByField) {
       throw new Error(
         'An orderBy function cannot be called more than once in the same query expression'
       );
+    }
+
+    if (!alreadyOrderedByField && fieldProp) {
+      this.orderByFields.add(fieldProp);
     }
 
     this.orderByObj = {


### PR DESCRIPTION
Description:
Store the fields that have been ordered by with (and throw if you try to
orderBy twice in the same field) instead of just checking if any fields
have been ordered by.
An orderBy function cannot be called more than once in the same query
expression, except in different fields.

Fixing issue https://github.com/wovalle/fireorm/issues/266