### PR TITLE
fix: Getter methods decorated with @Ignore() should not be present

### DIFF
--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -76,6 +76,31 @@ describe('Utils', () => {
       expect(serializeEntity(rhcp, [])).not.toHaveProperty('temporaryName');
     });
 
+    it('should not return getter properties with an Ignore() decorator', () => {
+      class Band implements IEntity {
+        id: string;
+        name: string;
+        
+        get removeFirstLetterOfName() {
+          if (!this.name) return ''
+          return this.name.charAt(0)
+        }
+
+        @Ignore()
+        get capitalizedName() {
+          if (!this.name) return ''
+          return this.name.charAt(0).toUpperCase() + this.name.slice(1)
+        }
+      }
+
+      const rhcp = new Band();
+      rhcp.name = 'red Hot Chili Peppers';
+
+      expect(serializeEntity(rhcp, [])).toHaveProperty('name');
+      expect(serializeEntity(rhcp, [])).toHaveProperty('removeFirstLetterOfName');
+      expect(serializeEntity(rhcp, [])).not.toHaveProperty('capitalizedName');
+    });
+
     it('should serialize object properties with the @Serialize() decorator', () => {
       class Address {
         streetName: string;

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -80,16 +80,16 @@ describe('Utils', () => {
       class Band implements IEntity {
         id: string;
         name: string;
-        
+
         get removeFirstLetterOfName() {
-          if (!this.name) return ''
-          return this.name.charAt(0)
+          if (!this.name) return '';
+          return this.name.charAt(0);
         }
 
         @Ignore()
         get capitalizedName() {
-          if (!this.name) return ''
-          return this.name.charAt(0).toUpperCase() + this.name.slice(1)
+          if (!this.name) return '';
+          return this.name.charAt(0).toUpperCase() + this.name.slice(1);
         }
       }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,13 +55,10 @@ export function serializeEntity<T extends IEntity>(
     delete serializableObj[scm.propertyKey];
   });
 
-  Object.keys(obj).forEach(propertyKey => {
+  Object.entries(serializableObj).forEach(([propertyKey, propertyValue]) => {
     if (Reflect.getMetadata(ignoreKey, obj, propertyKey) === true) {
       delete serializableObj[propertyKey];
     }
-  });
-
-  Object.entries(serializableObj).forEach(([propertyKey, propertyValue]) => {
     if (Reflect.getMetadata(serializeKey, obj, propertyKey) !== undefined) {
       if (Array.isArray(propertyValue)) {
         (serializableObj as { [key: string]: unknown })[propertyKey] = propertyValue.map(element =>


### PR DESCRIPTION
description:
Getter methods decorated with @Ignore() are still saved

https://github.com/wovalle/fireorm/issues/282