### PR TITLE
docs: fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This repo uses [Conventional Commits](https://www.conventionalcommits.org/) as t
 
 ### Release a new version
 
-This repo uses [Sematic Release](https://github.com/semantic-release/semantic-release) to automatically release new versions as soon as they land on master.
+This repo uses [Semantic Release](https://github.com/semantic-release/semantic-release) to automatically release new versions as soon as they land on master.
 
 Commits must follow [Angular's Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines).
 


### PR DESCRIPTION
This PR corrects a typo for the word "Semantic" in `README.md`.