### PR TITLE
Support for graceful handling of duplicate collections

### DIFF
--- a/src/MetadataStorage.spec.ts
+++ b/src/MetadataStorage.spec.ts
@@ -134,11 +134,17 @@ describe('MetadataStorage', () => {
       expect(collection.segments).toEqual([col.name]);
     });
 
-    it('should throw when trying to store duplicate collections', () => {
+    it('should not throw when trying to store duplicate collections', () => {
       metadataStorage.setCollection(col);
-      expect(() => metadataStorage.setCollection(col)).toThrowError(
-        `Collection with name ${col.name} has already been registered`
+      const collection = metadataStorage.collections.find(
+        c => c.entityConstructor === col.entityConstructor
       );
+
+      expect(collection.entityConstructor).toEqual(col.entityConstructor);
+      expect(collection.name).toEqual(col.name);
+      expect(collection.parentEntityConstructor).toEqual(col.parentEntityConstructor);
+      expect(collection.propertyKey).toEqual(col.propertyKey);
+      expect(collection.segments).toEqual([col.name]);
     });
 
     it('should update segments for nested subcollections', () => {

--- a/src/MetadataStorage.spec.ts
+++ b/src/MetadataStorage.spec.ts
@@ -134,17 +134,11 @@ describe('MetadataStorage', () => {
       expect(collection.segments).toEqual([col.name]);
     });
 
-    it('should not throw when trying to store duplicate collections', () => {
+    it('should throw when trying to store duplicate collections', () => {
       metadataStorage.setCollection(col);
-      const collection = metadataStorage.collections.find(
-        c => c.entityConstructor === col.entityConstructor
+      expect(() => metadataStorage.setCollection(col)).toThrowError(
+        `Collection with name ${col.name} has already been registered`
       );
-
-      expect(collection.entityConstructor).toEqual(col.entityConstructor);
-      expect(collection.name).toEqual(col.name);
-      expect(collection.parentEntityConstructor).toEqual(col.parentEntityConstructor);
-      expect(collection.propertyKey).toEqual(col.propertyKey);
-      expect(collection.segments).toEqual([col.name]);
     });
 
     it('should update segments for nested subcollections', () => {

--- a/src/MetadataStorage.ts
+++ b/src/MetadataStorage.ts
@@ -92,34 +92,33 @@ export class MetadataStorage {
   public setCollection = (col: CollectionMetadata) => {
     const existing = this.getCollection(col.entityConstructor);
 
-    if (existing) {
-      throw new Error(`Collection with name ${existing.name} has already been registered`);
-    }
-
-    const colToAdd = {
-      ...col,
-      segments: [col.name],
-    };
-
-    this.collections.push(colToAdd);
-
-    const getWhereImParent = (p: Constructor<IEntity>) =>
-      this.collections.filter(c => c.parentEntityConstructor === p);
-
-    const colsToUpdate = getWhereImParent(col.entityConstructor);
-
-    // Update segments for subcollections and subcollections of subcollections
-    while (colsToUpdate.length) {
-      const c = colsToUpdate.pop();
-
-      if (!c) {
-        return;
+    if (!existing) {
+      const colToAdd = {
+        ...col,
+        segments: [col.name],
+      };
+  
+      this.collections.push(colToAdd);
+  
+      const getWhereImParent = (p: Constructor<IEntity>) =>
+        this.collections.filter(c => c.parentEntityConstructor === p);
+  
+      const colsToUpdate = getWhereImParent(col.entityConstructor);
+  
+      // Update segments for subcollections and subcollections of subcollections
+      while (colsToUpdate.length) {
+        const c = colsToUpdate.pop();
+  
+        if (!c) {
+          return;
+        }
+  
+        const parent = this.collections.find(p => p.entityConstructor === c.parentEntityConstructor);
+        c.segments = parent?.segments.concat(c.name) || [];
+        getWhereImParent(c.entityConstructor).forEach(col => colsToUpdate.push(col));
       }
-
-      const parent = this.collections.find(p => p.entityConstructor === c.parentEntityConstructor);
-      c.segments = parent?.segments.concat(c.name) || [];
-      getWhereImParent(c.entityConstructor).forEach(col => colsToUpdate.push(col));
     }
+    return;
   };
 
   public getRepository = (param: IEntityConstructor) => {

--- a/src/MetadataUtils.ts
+++ b/src/MetadataUtils.ts
@@ -29,7 +29,7 @@ export const getMetadataStorage = (): MetadataStorage => {
 
 export const initialize = (
   firestore: Firestore,
-  config: MetadataStorageConfig = { validateModels: false, validatorOptions: {} }
+  config: MetadataStorageConfig = { validateModels: false, validatorOptions: {}, throwOnDuplicatedCollection: true }
 ): void => {
   initializeMetadataStorage();
 


### PR DESCRIPTION
When upgrading Fireorm from version 0.16.0 to 0.18.0, encountering an error related to duplicate collections and subcollections poses a challenge. The current behavior throws an error if duplicates are detected. It's possible to have collections and subcollections with the same name.

A more favorable approach would be for Fireorm to gracefully skip duplicates instead of halting execution with an error. 

This is implemented  by this Pull Request.